### PR TITLE
enable JIT with pid

### DIFF
--- a/StikJIT/StikJITApp.swift
+++ b/StikJIT/StikJITApp.swift
@@ -347,7 +347,8 @@ struct HeartbeatApp: App {
                                         show_alert = false
                                     },
                                     showButton: true,
-                                    primaryButtonText: "OK"
+                                    primaryButtonText: "OK",
+                                    messageType: .error
                                 )
                             }
                         }
@@ -370,21 +371,22 @@ struct HeartbeatApp: App {
     }
     
     func startProxy(callback: @escaping (Bool, Int?) -> Void) {
-        let port = 51820
-        let bindAddr = "127.0.0.1:\(port)"
-        
-        DispatchQueue.global(qos: .background).async {
-            let result = start_emotional_damage(bindAddr)
-            DispatchQueue.main.async {
-                if result == 0 {
-                    print("DEBUG: em_proxy started successfully on port \(port)")
-                    callback(true, nil)
-                } else {
-                    print("DEBUG: Failed to start em_proxy")
-                    callback(false, Int(result))
-                }
-            }
-        }
+//        let port = 51820
+//        let bindAddr = "127.0.0.1:\(port)"
+//        
+//        DispatchQueue.global(qos: .background).async {
+//            let result = start_emotional_damage(bindAddr)
+//            DispatchQueue.main.async {
+//                if result == 0 {
+//                    print("DEBUG: em_proxy started successfully on port \(port)")
+//                    callback(true, nil)
+//                } else {
+//                    print("DEBUG: Failed to start em_proxy")
+//                    callback(false, Int(result))
+//                }
+//            }
+//        }
+        callback(true, nil)
     }
     
     private func checkVPNConnection(callback: @escaping (Bool, String?) -> Void) {
@@ -666,7 +668,7 @@ struct LoadingView: View {
     }
 }
 
-public func showAlert(title: String, message: String, showOk: Bool, showTryAgain: Bool = false, primaryButtonText: String? = nil, completion: @escaping (Bool) -> Void) {
+public func showAlert(title: String, message: String, showOk: Bool, showTryAgain: Bool = false, primaryButtonText: String? = nil, messageType: MessageType = .error, completion: @escaping (Bool) -> Void) {
     DispatchQueue.main.async {
         let rootViewController = UIApplication.shared.windows.last?.rootViewController
         
@@ -682,7 +684,8 @@ public func showAlert(title: String, message: String, showOk: Bool, showTryAgain
                 primaryButtonText: primaryButtonText ?? "Try Again",
                 onPrimaryButtonTap: {
                     completion(true)
-                }
+                },
+                messageType: messageType
             )
             let hostingController = UIHostingController(rootView: customErrorView)
             hostingController.modalPresentationStyle = .overFullScreen
@@ -702,7 +705,8 @@ public func showAlert(title: String, message: String, showOk: Bool, showTryAgain
                 onPrimaryButtonTap: {
                     rootViewController?.presentedViewController?.dismiss(animated: true)
                     completion(true)
-                }
+                },
+                messageType: messageType
             )
             let hostingController = UIHostingController(rootView: customErrorView)
             hostingController.modalPresentationStyle = .overFullScreen
@@ -717,7 +721,8 @@ public func showAlert(title: String, message: String, showOk: Bool, showTryAgain
                     rootViewController?.presentedViewController?.dismiss(animated: true)
                     completion(false)
                 },
-                showButton: false
+                showButton: false,
+                messageType: messageType
             )
             let hostingController = UIHostingController(rootView: customErrorView)
             hostingController.modalPresentationStyle = .overFullScreen

--- a/StikJIT/StikJITApp.swift
+++ b/StikJIT/StikJITApp.swift
@@ -670,8 +670,10 @@ struct LoadingView: View {
 
 public func showAlert(title: String, message: String, showOk: Bool, showTryAgain: Bool = false, primaryButtonText: String? = nil, messageType: MessageType = .error, completion: @escaping (Bool) -> Void) {
     DispatchQueue.main.async {
-        let rootViewController = UIApplication.shared.windows.last?.rootViewController
-        
+        guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene else {
+            return
+        }
+        let rootViewController = scene.windows.first?.rootViewController
         if showTryAgain {
             let customErrorView = CustomErrorView(
                 title: title,

--- a/StikJIT/Views/Custom Error View.swift
+++ b/StikJIT/Views/Custom Error View.swift
@@ -7,6 +7,12 @@
 
 import SwiftUI
 
+public enum MessageType {
+    case error
+    case success
+    case info
+}
+
 struct CustomErrorView: View {
     var title: String
     var message: String
@@ -19,7 +25,7 @@ struct CustomErrorView: View {
     var onPrimaryButtonTap: (() -> Void)? = nil
     var onSecondaryButtonTap: (() -> Void)? = nil
     var showSecondaryButton: Bool = false
-    var messageType: MessageType = .error
+    var messageType: MessageType
     
     @Environment(\.colorScheme) private var colorScheme
     @AppStorage("customAccentColor") private var customAccentColorHex: String = ""
@@ -32,11 +38,6 @@ struct CustomErrorView: View {
         }
     }
     
-    enum MessageType {
-        case error
-        case success
-        case info
-    }
     
     var body: some View {
         ZStack {

--- a/StikJIT/Views/HomeView.swift
+++ b/StikJIT/Views/HomeView.swift
@@ -32,8 +32,12 @@ struct HomeView: View {
     @State private var isImportingFile = false
     @State private var importProgress: Float = 0.0
     
+    @State private var pidTextAlertShow = false
+    @State private var pidStr = ""
+    
     @State private var viewDidAppeared = false
     @State private var pendingBundleIdToEnableJIT : String? = nil
+    @State private var pendingPIDToEnableJIT : Int? = nil
     
     private var accentColor: Color {
         if customAccentColorHex.isEmpty {
@@ -98,6 +102,28 @@ struct HomeView: View {
                     .shadow(color: accentColor.opacity(0.3), radius: 8, x: 0, y: 4)
                 }
                 .padding(.horizontal, 20)
+                
+                
+                if pairingFileExists {
+                    Button(action: {
+                        pidTextAlertShow = true
+                    }) {
+                        HStack {
+                            Image(systemName: "bolt.fill")
+                                .font(.system(size: 20))
+                            Text("Connect by PID")
+                                .font(.system(.title3, design: .rounded))
+                                .fontWeight(.semibold)
+                        }
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(accentColor)
+                        .foregroundColor(accentColor.contrastText())
+                        .cornerRadius(16)
+                        .shadow(color: accentColor.opacity(0.3), radius: 8, x: 0, y: 4)
+                    }
+                    .padding(.horizontal, 20)
+                }
                 
                 // Status message area - keeps layout consistent
                 ZStack {
@@ -249,6 +275,28 @@ struct HomeView: View {
                 startJITInBackground(with: selectedBundle)
             }
         }
+        .textFieldAlert(
+            isPresented: $pidTextAlertShow,
+            title: "Please enter the PID of the process you want to connect to",
+            text: $pidStr,
+            placeholder: "",
+            action: { newText in
+
+                guard let pidStr = newText, pidStr != "" else {
+                    return
+                }
+                
+                guard let pid = Int(pidStr) else {
+                    showAlert(title: "", message: "Invalid PID", showOk: true, completion: { _ in })
+                    return
+                }
+                startJITInBackground(with: pid)
+                
+            },
+            actionCancel: {_ in
+                pidStr = ""
+            }
+        )
         .onOpenURL { url in
             print(url.path())
             if url.host() != "enable-jit" {
@@ -262,6 +310,12 @@ struct HomeView: View {
                 } else {
                     pendingBundleIdToEnableJIT = bundleId
                 }
+            } else if let pidStr = components?.queryItems?.first(where: { $0.name == "pid" })?.value, let pid = Int(pidStr) {
+                if viewDidAppeared {
+                    startJITInBackground(with: pid)
+                } else {
+                    pendingPIDToEnableJIT = pid
+                }
             }
             
         }
@@ -270,6 +324,10 @@ struct HomeView: View {
             if let pendingBundleIdToEnableJIT {
                 startJITInBackground(with: pendingBundleIdToEnableJIT)
                 self.pendingBundleIdToEnableJIT = nil
+            }
+            if let pendingPIDToEnableJIT {
+                startJITInBackground(with: pendingPIDToEnableJIT)
+                self.pendingPIDToEnableJIT = nil
             }
         }
     }
@@ -312,6 +370,34 @@ struct HomeView: View {
             
             DispatchQueue.main.async {
                 LogManager.shared.addInfoLog("JIT process completed for \(bundleID)")
+                isProcessing = false
+                
+                if success && doAutoQuitAfterEnablingJIT {
+                    exit(0)
+                }
+            }
+        }
+    }
+    
+    private func startJITInBackground(with pid: Int) {
+        isProcessing = true
+        
+        // Add log message
+        LogManager.shared.addInfoLog("Starting JIT for pid \(pid)")
+        
+        DispatchQueue.global(qos: .background).async {
+
+            let success = JITEnableContext.shared.debugApp(withPID: Int32(pid), logger: { message in
+
+                if let message = message {
+                    // Log messages from the JIT process
+                    LogManager.shared.addInfoLog(message)
+                }
+            })
+            
+            DispatchQueue.main.async {
+                LogManager.shared.addInfoLog("JIT process completed for \(pid)")
+                showAlert(title: "Success", message: "JIT has been enabled for pid \(pid).", showOk: true, messageType: .success, completion: { _ in })
                 isProcessing = false
                 
                 if success && doAutoQuitAfterEnablingJIT {

--- a/StikJIT/Views/TextFieldAlert.swift
+++ b/StikJIT/Views/TextFieldAlert.swift
@@ -1,0 +1,77 @@
+//
+//  TextAlert.swift
+//  StikJIT
+//
+//  Created by s s on 2025/5/11.
+//
+import SwiftUI
+import UIKit
+
+public struct TextFieldAlertModifier: ViewModifier {
+
+    @State private var alertController: UIAlertController?
+
+    @Binding var isPresented: Bool
+
+    let title: String
+    let text: Binding<String>
+    let placeholder: String
+    let action: (String?) -> Void
+    let actionCancel: (String?) -> Void
+
+    public func body(content: Content) -> some View {
+        content.onChange(of: isPresented) { isPresented in
+            if isPresented, alertController == nil {
+                let alertController = makeAlertController()
+                self.alertController = alertController
+                
+                guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene else {
+                    return
+                }
+                scene.windows.first?.rootViewController?.present(alertController, animated: true)
+            } else if !isPresented, let alertController = alertController {
+                alertController.dismiss(animated: true)
+                self.alertController = nil
+            }
+        }
+    }
+
+    private func makeAlertController() -> UIAlertController {
+        let controller = UIAlertController(title: title, message: nil, preferredStyle: .alert)
+        controller.addTextField {
+            $0.placeholder = self.placeholder
+            $0.text = self.text.wrappedValue
+            $0.clearButtonMode = .always
+        }
+        controller.addAction(UIAlertAction(title: "Cancel", style: .cancel) { _ in
+            self.actionCancel(nil)
+            shutdown()
+        })
+        controller.addAction(UIAlertAction(title: "OK", style: .default) { _ in
+            self.action(controller.textFields?.first?.text)
+            shutdown()
+        })
+        return controller
+    }
+
+    private func shutdown() {
+        isPresented = false
+        alertController = nil
+    }
+
+}
+
+
+extension View {
+    
+    public func textFieldAlert(
+        isPresented: Binding<Bool>,
+        title: String,
+        text: Binding<String>,
+        placeholder: String = "",
+        action: @escaping (String?) -> Void,
+        actionCancel: @escaping (String?) -> Void
+    ) -> some View {
+        self.modifier(TextFieldAlertModifier(isPresented: isPresented, title: title, text: text, placeholder: placeholder, action: action, actionCancel: actionCancel))
+    }
+}

--- a/StikJIT/idevice/JITEnableContext.h
+++ b/StikJIT/idevice/JITEnableContext.h
@@ -17,6 +17,7 @@ typedef void (^LogFunc)(NSString *message);
 - (IdevicePairingFile*)getPairingFileWithError:(NSError**)error;
 - (void)startHeartbeatWithCompletionHandler:(HeartbeatCompletionHandler)completionHandler logger:(LogFunc)logger;
 - (BOOL)debugAppWithBundleID:(NSString*)bundleID logger:(LogFunc)logger;
+- (BOOL)debugAppWithPID:(int)pid logger:(LogFunc)logger;
 - (NSDictionary<NSString*, NSString*>*)getAppListWithError:(NSError**)error;
 - (UIImage*)getAppIconWithBundleId:(NSString*)bundleId error:(NSError**)error;
 @end

--- a/StikJIT/idevice/JITEnableContext.m
+++ b/StikJIT/idevice/JITEnableContext.m
@@ -133,6 +133,19 @@ JITEnableContext* sharedJITContext = nil;
                      [self createCLogger:logger]) == 0;
 }
 
+- (BOOL)debugAppWithPID:(int)pid logger:(LogFunc)logger {
+    if (!provider) {
+        if (logger) {
+            logger(@"Provider not initialized!");
+        }
+        NSLog(@"Provider not initialized!");
+        return NO;
+    }
+    return debug_app_pid(provider,
+                     pid,
+                     [self createCLogger:logger]) == 0;
+}
+
 - (NSDictionary<NSString*, NSString*>*)getAppListWithError:(NSError**)error {
     if (!provider) {
         NSLog(@"Provider not initialized!");

--- a/StikJIT/idevice/jit.c
+++ b/StikJIT/idevice/jit.c
@@ -263,3 +263,229 @@ int debug_app(TcpProviderHandle* tcp_provider, const char *bundle_id, LogFuncC l
     logger("Debug session completed");
     return 0;
 }
+
+
+int debug_app_pid(TcpProviderHandle* tcp_provider, int pid, LogFuncC logger) {
+    // Connect to CoreDeviceProxy
+    CoreDeviceProxyHandle *core_device = NULL;
+    IdeviceErrorCode err = core_device_proxy_connect_tcp(tcp_provider, &core_device);
+    if (err != IdeviceSuccess) {
+        logger("Failed to connect to CoreDeviceProxy: %d", err);
+        return 1;
+    }
+    
+    // Get server RSD port
+    uint16_t rsd_port;
+    err = core_device_proxy_get_server_rsd_port(core_device, &rsd_port);
+    if (err != IdeviceSuccess) {
+        logger("Failed to get server RSD port: %d", err);
+        core_device_proxy_free(core_device);
+        return 1;
+    }
+    logger("Server RSD Port: %d", rsd_port);
+    
+    /*****************************************************************
+     * Create TCP Tunnel Adapter
+     *****************************************************************/
+    logger("=== Creating TCP Tunnel Adapter ===");
+    
+    AdapterHandle *adapter = NULL;
+    err = core_device_proxy_create_tcp_adapter(core_device, &adapter);
+    if (err != IdeviceSuccess) {
+        logger("Failed to create TCP adapter: %d", err);
+        core_device_proxy_free(core_device);
+        return 1;
+    }
+    
+    // Connect to RSD port
+    err = adapter_connect(adapter, rsd_port);
+    if (err != IdeviceSuccess) {
+        logger("Failed to connect to RSD port: %d", err);
+        adapter_free(adapter);
+        return 1;
+    }
+    logger("Successfully connected to RSD port");
+    
+    /*****************************************************************
+     * XPC Device Setup
+     *****************************************************************/
+    logger("=== Setting up XPC Device ===");
+    
+    XPCDeviceAdapterHandle *xpc_device = NULL;
+    err = xpc_device_new(adapter, &xpc_device);
+    if (err != IdeviceSuccess) {
+        logger("Failed to create XPC device: %d", err);
+        adapter_free(adapter);
+        return 1;
+    }
+    
+    // Get DebugProxy service
+    XPCServiceHandle *debug_service = NULL;
+    err = xpc_device_get_service(xpc_device, "com.apple.internal.dt.remote.debugproxy", &debug_service);
+    if (err != IdeviceSuccess) {
+        logger("Failed to get debug proxy service: %d", err);
+        xpc_device_free(xpc_device);
+        return 1;
+    }
+    
+    // Get ProcessControl service
+    XPCServiceHandle *pc_service = NULL;
+    err = xpc_device_get_service(xpc_device, "com.apple.instruments.dtservicehub", &pc_service);
+    if (err != IdeviceSuccess) {
+        logger("Failed to get process control service: %d", err);
+        xpc_device_free(xpc_device);
+        return 1;
+    }
+    
+    /*****************************************************************
+     * Process Control - Launch App
+     *****************************************************************/
+    logger("=== Launching App ===");
+
+    // Get the adapter back from the XPC device
+
+    AdapterHandle *pc_adapter = NULL;
+    err = xpc_device_adapter_into_inner(xpc_device, &pc_adapter);
+    if (err != IdeviceSuccess) {
+        logger("Failed to extract adapter: %d", err);
+        xpc_device_free(xpc_device);
+        return 1;
+    }
+    
+    // Connect to process control port
+    err = adapter_connect(pc_adapter, pc_service->port);
+    if (err != IdeviceSuccess) {
+        logger("Failed to connect to process control port: %d", err);
+        adapter_free(pc_adapter);
+        xpc_service_free(pc_service);
+        xpc_service_free(debug_service);
+        return 1;
+    }
+    logger("Successfully connected to process control port");
+    
+    // Create RemoteServerClient
+    RemoteServerAdapterHandle *remote_server = NULL;
+    err = remote_server_adapter_new(pc_adapter, &remote_server);
+    if (err != IdeviceSuccess) {
+        logger("Failed to create remote server: %d", err);
+        adapter_free(pc_adapter);
+        xpc_service_free(pc_service);
+        xpc_service_free(debug_service);
+        return 1;
+    }
+    
+    // Create ProcessControlClient
+    ProcessControlAdapterHandle *process_control = NULL;
+    err = process_control_new(remote_server, &process_control);
+    if (err != IdeviceSuccess) {
+        logger("Failed to create process control client: %d", err);
+        remote_server_free(remote_server);
+        xpc_service_free(pc_service);
+        xpc_service_free(debug_service);
+        return 1;
+    }
+   
+    // Disable memory limit for PID
+    err = process_control_disable_memory_limit(process_control, pid);
+    if (err != IdeviceSuccess) {
+        logger("failed to disable memory limit: %d", err);
+    }
+    
+    /*****************************************************************
+     * Debug Proxy - Attach to Process
+     *****************************************************************/
+    logger("=== Attaching Debugger ===");
+    
+    // Get the adapter back from the remote server
+    AdapterHandle *debug_adapter = NULL;
+    err = remote_server_adapter_into_inner(remote_server, &debug_adapter);
+    if (err != IdeviceSuccess) {
+        logger("Failed to extract adapter: %d", err);
+        xpc_service_free(debug_service);
+        process_control_free(process_control);
+        remote_server_free(remote_server);
+        xpc_service_free(pc_service);
+        return 1;
+    }
+    
+    // Connect to debug proxy port
+    err = adapter_connect(debug_adapter, debug_service->port);
+    if (err != IdeviceSuccess) {
+        logger("Failed to connect to debug proxy port: %d", err);
+        adapter_free(debug_adapter);
+        xpc_service_free(debug_service);
+        process_control_free(process_control);
+        remote_server_free(remote_server);
+        xpc_service_free(pc_service);
+        return 1;
+    }
+    logger("Successfully connected to debug proxy port");
+    
+    // Create DebugProxyClient
+    DebugProxyAdapterHandle *debug_proxy = NULL;
+    err = debug_proxy_adapter_new(debug_adapter, &debug_proxy);
+    if (err != IdeviceSuccess) {
+        logger("Failed to create debug proxy client: %d", err);
+        adapter_free(debug_adapter);
+        xpc_service_free(debug_service);
+        process_control_free(process_control);
+        remote_server_free(remote_server);
+        xpc_service_free(pc_service);
+        return 1;
+    }
+    
+    // Send vAttach command with PID in hex
+    char attach_command[64];
+    snprintf(attach_command, sizeof(attach_command), "vAttach;%" PRIx64, pid);
+    
+    DebugserverCommandHandle *attach_cmd = debugserver_command_new(attach_command, NULL, 0);
+    if (attach_cmd == NULL) {
+        logger("Failed to create attach command");
+        debug_proxy_free(debug_proxy);
+        xpc_service_free(debug_service);
+        process_control_free(process_control);
+        remote_server_free(remote_server);
+        xpc_service_free(pc_service);
+        return 1;
+    }
+    
+    char *attach_response = NULL;
+    err = debug_proxy_send_command(debug_proxy, attach_cmd, &attach_response);
+    debugserver_command_free(attach_cmd);
+    
+    if (err != IdeviceSuccess) {
+        logger("Failed to attach to process: %d", err);
+    } else if (attach_response != NULL) {
+        logger("Attach response: %s", attach_response);
+        idevice_string_free(attach_response);
+    }
+    
+    // Send detach command
+    DebugserverCommandHandle *detach_cmd = debugserver_command_new("D", NULL, 0);
+    if (detach_cmd == NULL) {
+        logger("Failed to create detach command");
+    } else {
+        char *detach_response = NULL;
+        err = debug_proxy_send_command(debug_proxy, detach_cmd, &detach_response);
+        err = debug_proxy_send_command(debug_proxy, detach_cmd, &detach_response);
+        err = debug_proxy_send_command(debug_proxy, detach_cmd, &detach_response);
+        debugserver_command_free(detach_cmd);
+        
+        if (err != IdeviceSuccess) {
+            logger("Failed to detach from process: %d", err);
+        } else if (detach_response != NULL) {
+            logger("Detach response: %s", detach_response);
+            idevice_string_free(detach_response);
+        }
+    }
+    
+    /*****************************************************************
+     * Cleanup
+     *****************************************************************/
+    debug_proxy_free(debug_proxy);
+    xpc_service_free(debug_service);
+    xpc_service_free(pc_service);
+    
+    logger("Debug session completed");
+    return 0;
+}

--- a/StikJIT/idevice/jit.h
+++ b/StikJIT/idevice/jit.h
@@ -12,5 +12,6 @@
 
 typedef void (^LogFuncC)(const char* message, ...);
 int debug_app(TcpProviderHandle* provider, const char *bundle_id, LogFuncC logger);
+int debug_app_pid(TcpProviderHandle* provider, int pid, LogFuncC logger);
 
 #endif /* JIT_H */


### PR DESCRIPTION
1. Users can now enable JIT for an app by PID (mainly for LiveContainer's multitasking feature) through StikJIT's UI or URL scheme.
2. Did some change to the custom alert related code so it can show success icon.
3. Removed emproxy related code as we rely on StosVPN now.