### PR TITLE
Fix initialization and CFType handling

### DIFF
--- a/StikJIT/Utilities/Security.swift
+++ b/StikJIT/Utilities/Security.swift
@@ -30,6 +30,13 @@ func checkAppEntitlement(_ ent: String) -> Bool {
         print("Failed to get entitlements")
         return false
     }
-    
-    return entitlements.boolValue != nil && entitlements.boolValue
+
+    // CFTypeRef can be either a CFBoolean or CFNumber representing a boolean
+    if let value = entitlements as? CFBoolean {
+        return CFBooleanGetValue(value)
+    } else if let number = entitlements as? NSNumber {
+        return number.boolValue
+    } else {
+        return false
+    }
 }

--- a/StikJIT/Utilities/mountDDI.swift
+++ b/StikJIT/Utilities/mountDDI.swift
@@ -92,7 +92,7 @@ func isMounted() -> Bool {
     let listError = image_mounter_copy_devices(client, &devices, &devicesLen)
     if listError == IdeviceSuccess {
         let deviceList = devices?.assumingMemoryBound(to: plist_t.self)
-        var devices: [String] = []
+        var deviceIdentifiers: [String] = []
         for i in 0..<devicesLen {
             let device = deviceList?[i]
             var xmlData: UnsafeMutablePointer<CChar>?
@@ -101,14 +101,14 @@ func isMounted() -> Bool {
             // Use libplist function to convert to XML
             plist_to_xml(device, &xmlData, &xmlLength)
             if let xml = xmlData {
-                devices.append("\(xml)")
+                deviceIdentifiers.append("\(xml)")
             }
             plist_mem_free(xmlData)
             plist_free(device)
         }
 
         image_mounter_free(client)
-        return devices.count != 0
+        return deviceIdentifiers.count != 0
     } else {
         print("Failed to get device list: \(listError)")
         return false

--- a/StikJIT/idevice/JITEnableContext.m
+++ b/StikJIT/idevice/JITEnableContext.m
@@ -30,10 +30,13 @@ JITEnableContext* sharedJITContext = nil;
 }
 
 - (instancetype)init {
-    NSFileManager* fm = [NSFileManager defaultManager];
-    NSURL* docPathUrl = [fm URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask].firstObject;
-    NSURL* logURL = [docPathUrl URLByAppendingPathComponent:@"idevice_log.txt"];
-    idevice_init_logger(Debug, Debug, (char*)logURL.path.UTF8String);
+    self = [super init];
+    if (self) {
+        NSFileManager* fm = [NSFileManager defaultManager];
+        NSURL* docPathUrl = [fm URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask].firstObject;
+        NSURL* logURL = [docPathUrl URLByAppendingPathComponent:@"idevice_log.txt"];
+        idevice_init_logger(Debug, Debug, (char*)logURL.path.UTF8String);
+    }
     return self;
 }
 


### PR DESCRIPTION
## Summary
- fix CFTypeRef boolean checks in Security helper
- avoid variable shadowing when parsing device list
- properly initialize Objective-C JITEnableContext class

## Testing
- `make package` *(fails: set -o pipefail not supported)*

------
https://chatgpt.com/codex/tasks/task_e_683f8ef04a10832d9017abfe10bee488