### PR TITLE
Add VPN auto-start option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,10 @@
 
 ## Features  
 - On-device debugging/Just-In-Time (JIT) compilation for supported apps via [`idevice`](https://github.com/jkcoxson/idevice).  
-- Seamless integration with our custom built loopback vpn.  
-- Native UI for managing debugging/JIT-enabling.  
+- Seamless integration with **StikVPN**, our custom loopback VPN.
+- Built-in StikVPN management to enable or disable the connection.
+- Option to disable StikVPN auto start at launch.
+- Native UI for managing debugging/JIT-enabling.
 - No data collection—ensuring full privacy. 
 
 ## License  

--- a/StikJIT/StikJITApp.swift
+++ b/StikJIT/StikJITApp.swift
@@ -435,6 +435,7 @@ var pubHeartBeat = false
 @main
 struct HeartbeatApp: App {
     @AppStorage("hasLaunchedBefore") var hasLaunchedBefore: Bool = false
+    @AppStorage("autoStartVPN") private var autoStartVPN = true
     @State private var showWelcomeSheet: Bool = false
     @State private var isLoading2 = true
     @State private var isPairing = false
@@ -623,7 +624,7 @@ struct HeartbeatApp: App {
                 // Otherwise, start the VPN automatically.
                 if !hasLaunchedBefore {
                     showWelcomeSheet = true
-                } else {
+                } else if autoStartVPN {
                     TunnelManager.shared.startVPN()
                 }
             }
@@ -632,7 +633,9 @@ struct HeartbeatApp: App {
                     // When the user taps "Continue", mark the app as launched and start the VPN.
                     hasLaunchedBefore = true
                     showWelcomeSheet = false
-                    TunnelManager.shared.startVPN()
+                    if autoStartVPN {
+                        TunnelManager.shared.startVPN()
+                    }
                 }
             }
         }

--- a/StikJIT/Views/MainTabView.swift
+++ b/StikJIT/Views/MainTabView.swift
@@ -24,6 +24,12 @@ struct MainTabView: View {
                 .tabItem {
                     Label("Home", systemImage: "house")
                 }
+
+            StikVPNManagementView()
+                .tabItem {
+                    Label("StikVPN", systemImage: "lock.shield")
+                }
+
             SettingsView()
                 .tabItem {
                     Label("Settings", systemImage: "gearshape.fill")

--- a/StikJIT/Views/StikVPNManagementView.swift
+++ b/StikJIT/Views/StikVPNManagementView.swift
@@ -1,0 +1,72 @@
+import SwiftUI
+import NetworkExtension
+
+struct StikVPNManagementView: View {
+    @ObservedObject private var tunnelManager = TunnelManager.shared
+    @AppStorage("customAccentColor") private var customAccentColorHex: String = ""
+    @AppStorage("autoStartVPN") private var autoStartVPN = true
+    @Environment(\.colorScheme) private var colorScheme
+
+    private var accentColor: Color {
+        if customAccentColorHex.isEmpty {
+            return .blue
+        } else {
+            return Color(hex: customAccentColorHex) ?? .blue
+        }
+    }
+
+    var body: some View {
+        ZStack {
+            Color(UIColor.systemBackground)
+                .edgesIgnoringSafeArea(.all)
+
+            VStack(spacing: 24) {
+                Spacer()
+
+                VStack(spacing: 8) {
+                    Text("StikVPN Status")
+                        .font(.headline)
+                        .foregroundColor(.secondary)
+                    Text(tunnelManager.tunnelStatus.rawValue)
+                        .font(.title)
+                        .fontWeight(.bold)
+                }
+
+                Button(action: toggleVPN) {
+                    HStack {
+                        Image(systemName: tunnelManager.tunnelStatus == .connected ? "xmark" : "checkmark")
+                            .font(.system(size: 20))
+                        Text(tunnelManager.tunnelStatus == .connected ? "Disable StikVPN" : "Enable StikVPN")
+                            .font(.system(.title3, design: .rounded))
+                            .fontWeight(.semibold)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(accentColor)
+                    .foregroundColor(accentColor.contrastText())
+                    .cornerRadius(16)
+                    .shadow(color: accentColor.opacity(0.3), radius: 8, x: 0, y: 4)
+                }
+                .padding(.horizontal, 40)
+
+                Toggle("Start StikVPN Automatically", isOn: $autoStartVPN)
+                    .padding(.horizontal, 40)
+                
+                Spacer()
+            }
+        }
+    }
+
+    private func toggleVPN() {
+        switch tunnelManager.tunnelStatus {
+        case .connected, .connecting:
+            tunnelManager.stopVPN()
+        case .disconnected, .error, .disconnecting:
+            tunnelManager.startVPN()
+        }
+    }
+}
+
+#Preview {
+    StikVPNManagementView()
+}


### PR DESCRIPTION
## Summary
- allow disabling StikVPN auto-start at launch
- support toggle in management view and app lifecycle
- document auto-start option in README

## Testing
- `swift --version`
- `swiftc --version`

------
https://chatgpt.com/codex/tasks/task_e_683f9390759c832dbb6d8f2c6818889d