### PR TITLE
Add announcements to home view

### DIFF
--- a/StikJIT/Resources/announcements.json
+++ b/StikJIT/Resources/announcements.json
@@ -2,11 +2,17 @@
   {
     "id": 1,
     "title": "Welcome!",
-    "body": "Thank you for using StikDebug. Stay tuned for updates."
+    "body": "Thank you for using StikDebug. Stay tuned for updates.",
+    "date": "2025-06-04",
+    "time": "12:00",
+    "visible": true
   },
   {
     "id": 2,
     "title": "New Feature",
-    "body": "Announcements are now shown on the home screen."
+    "body": "Announcements are now shown on the home screen.",
+    "date": "2025-06-04",
+    "time": "12:30",
+    "visible": true
   }
 ]

--- a/StikJIT/Resources/announcements.json
+++ b/StikJIT/Resources/announcements.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": 1,
+    "title": "Welcome!",
+    "body": "Thank you for using StikDebug. Stay tuned for updates."
+  },
+  {
+    "id": 2,
+    "title": "New Feature",
+    "body": "Announcements are now shown on the home screen."
+  }
+]

--- a/StikJIT/Utilities/AnnouncementManager.swift
+++ b/StikJIT/Utilities/AnnouncementManager.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+struct Announcement: Identifiable, Codable {
+    let id: Int
+    let title: String
+    let body: String
+}
+
+class AnnouncementManager {
+    static func loadAnnouncements() -> [Announcement] {
+        guard let url = Bundle.main.url(forResource: "announcements", withExtension: "json"),
+              let data = try? Data(contentsOf: url),
+              let announcements = try? JSONDecoder().decode([Announcement].self, from: data) else {
+            return []
+        }
+        return announcements
+    }
+}

--- a/StikJIT/Utilities/AnnouncementManager.swift
+++ b/StikJIT/Utilities/AnnouncementManager.swift
@@ -7,12 +7,27 @@ struct Announcement: Identifiable, Codable {
 }
 
 class AnnouncementManager {
-    static func loadAnnouncements() -> [Announcement] {
-        guard let url = Bundle.main.url(forResource: "announcements", withExtension: "json"),
-              let data = try? Data(contentsOf: url),
-              let announcements = try? JSONDecoder().decode([Announcement].self, from: data) else {
-            return []
+    private static let announcementsURL = "https://raw.githubusercontent.com/0-Blu/StikJIT/main/StikJIT/Resources/announcements.json"
+
+    static func fetchAnnouncements(completion: @escaping ([Announcement]) -> Void) {
+        guard let url = URL(string: announcementsURL) else {
+            completion([])
+            return
         }
-        return announcements
+
+        URLSession.shared.dataTask(with: url) { data, response, _ in
+            guard let data = data,
+                  (response as? HTTPURLResponse)?.statusCode == 200,
+                  let announcements = try? JSONDecoder().decode([Announcement].self, from: data) else {
+                DispatchQueue.main.async {
+                    completion([])
+                }
+                return
+            }
+
+            DispatchQueue.main.async {
+                completion(announcements)
+            }
+        }.resume()
     }
 }

--- a/StikJIT/Utilities/AnnouncementManager.swift
+++ b/StikJIT/Utilities/AnnouncementManager.swift
@@ -4,6 +4,9 @@ struct Announcement: Identifiable, Codable {
     let id: Int
     let title: String
     let body: String
+    let date: String
+    let time: String
+    let visible: Bool
 }
 
 class AnnouncementManager {
@@ -25,8 +28,10 @@ class AnnouncementManager {
                 return
             }
 
+            let visibleAnnouncements = announcements.filter { $0.visible }
+
             DispatchQueue.main.async {
-                completion(announcements)
+                completion(visibleAnnouncements)
             }
         }.resume()
     }

--- a/StikJIT/Views/AnnouncementCard.swift
+++ b/StikJIT/Views/AnnouncementCard.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+struct AnnouncementCard: View {
+    var announcement: Announcement
+    @AppStorage("customAccentColor") private var customAccentColorHex: String = ""
+
+    private var accentColor: Color {
+        if customAccentColorHex.isEmpty {
+            return .blue
+        } else {
+            return Color(hex: customAccentColorHex) ?? .blue
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(announcement.title)
+                .font(.headline)
+                .foregroundColor(.primary)
+            Text(announcement.body)
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(UIColor.secondarySystemBackground))
+        .overlay(
+            RoundedRectangle(cornerRadius: 16)
+                .stroke(accentColor, lineWidth: 2)
+        )
+        .cornerRadius(16)
+        .shadow(color: Color.black.opacity(0.08), radius: 3, x: 0, y: 2)
+    }
+}
+
+#Preview {
+    AnnouncementCard(announcement: Announcement(id: 0, title: "Title", body: "Body"))
+}

--- a/StikJIT/Views/AnnouncementCard.swift
+++ b/StikJIT/Views/AnnouncementCard.swift
@@ -20,6 +20,9 @@ struct AnnouncementCard: View {
             Text(announcement.body)
                 .font(.subheadline)
                 .foregroundColor(.secondary)
+            Text("\(announcement.date) \(announcement.time)")
+                .font(.caption)
+                .foregroundColor(.secondary)
         }
         .padding()
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -34,5 +37,14 @@ struct AnnouncementCard: View {
 }
 
 #Preview {
-    AnnouncementCard(announcement: Announcement(id: 0, title: "Title", body: "Body"))
+    AnnouncementCard(
+        announcement: Announcement(
+            id: 0,
+            title: "Title",
+            body: "Body",
+            date: "2025-01-01",
+            time: "00:00",
+            visible: true
+        )
+    )
 }

--- a/StikJIT/Views/HomeView.swift
+++ b/StikJIT/Views/HomeView.swift
@@ -8,6 +8,9 @@
 import SwiftUI
 import UniformTypeIdentifiers
 
+// Load announcements from bundled JSON
+import Foundation
+
 extension UIDocumentPickerViewController {
     @objc func fix_init(forOpeningContentTypes contentTypes: [UTType], asCopy: Bool) -> UIDocumentPickerViewController {
         return fix_init(forOpeningContentTypes: contentTypes, asCopy: true)
@@ -32,6 +35,8 @@ struct HomeView: View {
     @State private var isImportingFile = false
     @State private var showingConsoleLogsView = false
     @State private var importProgress: Float = 0.0
+
+    @State private var announcements: [Announcement] = []
     
     @State private var pidTextAlertShow = false
     @State private var pidStr = ""
@@ -60,14 +65,23 @@ struct HomeView: View {
                     Text("Welcome to StikDebug \(username)!")
                         .font(.system(.largeTitle, design: .rounded))
                         .fontWeight(.bold)
-                    
+
                     Text(pairingFileExists ? "Click connect to get started" : "Pick pairing file to get started")
                         .font(.system(.subheadline, design: .rounded))
                         .foregroundStyle(.secondary)
                         .multilineTextAlignment(.center)
                 }
                 .padding(.top, 40)
-                
+
+                if !announcements.isEmpty {
+                    VStack(spacing: 12) {
+                        ForEach(announcements) { announcement in
+                            AnnouncementCard(announcement: announcement)
+                        }
+                    }
+                    .padding(.horizontal, 20)
+                }
+
                 Button(action: {
                     
                     
@@ -203,10 +217,12 @@ struct HomeView: View {
             checkPairingFileExists()
             // Don't initialize specific color value when empty - empty means "use system theme"
             // This was causing the toggle to turn off when returning to settings
-            
+
             // Initialize background color
             refreshBackground()
-            
+
+            announcements = AnnouncementManager.loadAnnouncements()
+
             // Add notification observer for showing pairing file picker
             NotificationCenter.default.addObserver(
                 forName: NSNotification.Name("ShowPairingFilePicker"),

--- a/StikJIT/Views/HomeView.swift
+++ b/StikJIT/Views/HomeView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 import UniformTypeIdentifiers
 
-// Load announcements from bundled JSON
+// Load announcements from remote JSON
 import Foundation
 
 extension UIDocumentPickerViewController {
@@ -221,7 +221,9 @@ struct HomeView: View {
             // Initialize background color
             refreshBackground()
 
-            announcements = AnnouncementManager.loadAnnouncements()
+            AnnouncementManager.fetchAnnouncements { loaded in
+                announcements = loaded
+            }
 
             // Add notification observer for showing pairing file picker
             NotificationCenter.default.addObserver(


### PR DESCRIPTION
## Summary
- show announcements on app startup
- load announcements from `announcements.json`
- style announcement cards

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684033bf8c10832d8b342cd214b19fa1