### PR TITLE
Ensure heartbeat happened recently before enabling jit

### DIFF
--- a/StikJIT/idevice/JITEnableContext.m
+++ b/StikJIT/idevice/JITEnableContext.m
@@ -120,6 +120,15 @@ JITEnableContext* sharedJITContext = nil;
     );
 }
 
+- (void)ensureHeartbeat {
+    // wait a bit until heartbeat finish. wait at most 10s
+    int deadline = 50;
+    while((!lastHeartbeatDate || [[NSDate now] timeIntervalSinceDate:lastHeartbeatDate] > 15) && deadline) {
+        --deadline;
+        usleep(200);
+    }
+}
+
 - (BOOL)debugAppWithBundleID:(NSString*)bundleID logger:(LogFunc)logger {
     if (!provider) {
         if (logger) {
@@ -128,6 +137,9 @@ JITEnableContext* sharedJITContext = nil;
         NSLog(@"Provider not initialized!");
         return NO;
     }
+    
+    [self ensureHeartbeat];
+    
     return debug_app(provider,
                      [bundleID UTF8String],
                      [self createCLogger:logger]) == 0;
@@ -141,6 +153,9 @@ JITEnableContext* sharedJITContext = nil;
         NSLog(@"Provider not initialized!");
         return NO;
     }
+    
+    [self ensureHeartbeat];
+    
     return debug_app_pid(provider,
                      pid,
                      [self createCLogger:logger]) == 0;

--- a/StikJIT/idevice/heartbeat.h
+++ b/StikJIT/idevice/heartbeat.h
@@ -9,11 +9,13 @@
 #ifndef HEARTBEAT_H
 #define HEARTBEAT_H
 #include "idevice.h"
+@import Foundation;
 
 typedef void (^HeartbeatCompletionHandlerC)(int result, const char *message);
 typedef void (^LogFuncC)(const char* message, ...);
 
 extern bool isHeartbeat;
+extern NSDate* lastHeartbeatDate;
 
 void startHeartbeat(IdevicePairingFile* pairintFile, TcpProviderHandle** provider, int* heartbeatSessionId, HeartbeatCompletionHandlerC completion, LogFuncC logger);
 

--- a/StikJIT/idevice/heartbeat.m
+++ b/StikJIT/idevice/heartbeat.m
@@ -13,7 +13,7 @@
 
 
 bool isHeartbeat = false;
-
+NSDate* lastHeartbeatDate = nil;
 
 void startHeartbeat(IdevicePairingFile* pairing_file, TcpProviderHandle** provider, int* heartbeatSessionId, HeartbeatCompletionHandlerC completion, LogFuncC logger) {
     int currentSessionId = *heartbeatSessionId;
@@ -82,6 +82,7 @@ void startHeartbeat(IdevicePairingFile* pairing_file, TcpProviderHandle** provid
             return;
         }
         logger("DEBUG: Polo reply sent successfully.");
+        lastHeartbeatDate = [NSDate date];
         isHeartbeat = true;
     }
 }


### PR DESCRIPTION
When StikDebug goes to background and got suspended, heartbeat stops, and when user uses URL Scheme to enable jit, it is highly likely that it has been a long time since last heartbeat, which make jit enabling fail.

This pr ensures that the last heartbeat happened within 15 seconds.