### PR TITLE
Fix PiP playback

### DIFF
--- a/StikJIT/JSSupport/PiPController.swift
+++ b/StikJIT/JSSupport/PiPController.swift
@@ -30,10 +30,11 @@ struct VideoPlayerView: UIViewRepresentable {
         let asset = AVAsset(url: videoURL)
         let playerItem = AVPlayerItem(asset: asset)
         let player = AVPlayer(playerItem: playerItem)
-        
+
         playerLayer.player = player
         player.isMuted = true
         player.allowsExternalPlayback = true
+        player.play()
         
         containerView.layer.addSublayer(playerLayer)
         


### PR DESCRIPTION
## Summary
- make the PiP player actually play the backing video

## Testing
- `swift --version`
- `swift test` *(fails: Could not find Package.swift)*
- `make package` *(fails: xcodebuild not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870261533cc832d95cf3d7d9b9bf75e