### PR TITLE
Gate PiP on default script option

### DIFF
--- a/StikJIT/Views/HomeView.swift
+++ b/StikJIT/Views/HomeView.swift
@@ -303,7 +303,10 @@ struct HomeView: View {
                 startJITInBackground(with: selectedBundle)
             }
         }
-        .pipify(isPresented: $isProcessing) {
+        .pipify(isPresented: Binding(
+            get: { useDefaultScript && isProcessing },
+            set: { newValue in isProcessing = newValue }
+        )) {
             RunJSViewPiP(model: $jsModel)
         }
         .sheet(isPresented: $scriptViewShow) {

--- a/StikJIT/Views/SettingsView.swift
+++ b/StikJIT/Views/SettingsView.swift
@@ -272,16 +272,23 @@ struct SettingsView: View {
                                                    .foregroundColor(.primary)
                                                    .padding(.bottom, 4)
                                                
-                                               Toggle("Run Default Script After Connecting", isOn: $useDefaultScript)
-                                                   .foregroundColor(.primary)
-                                                   .padding(.vertical, 6)
-
                                                Toggle("Enable Advanced Options", isOn: $enableAdvancedOptions)
                                                    .foregroundColor(.primary)
                                                    .padding(.vertical, 6)
+
+                                               if enableAdvancedOptions {
+                                                   Toggle("Run Default Script After Connecting", isOn: $useDefaultScript)
+                                                       .foregroundColor(.primary)
+                                                       .padding(.vertical, 6)
+                                               }
                                            }
                                            .padding(.vertical, 20)
                                            .padding(.horizontal, 16)
+                                           .onChange(of: enableAdvancedOptions) { _, newValue in
+                                               if !newValue {
+                                                   useDefaultScript = false
+                                               }
+                                           }
                                        }
                                        
                     // About section


### PR DESCRIPTION
## Summary
- display the `Run Default Script After Connecting` toggle only when advanced options are enabled
- ensure the toggle resets to off when Advanced Options are disabled
- show PiP only when `Run Default Script After Connecting` is on

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `make package` *(fails: set: Illegal option -o pipefail)*

------
https://chatgpt.com/codex/tasks/task_e_68726d9cbcac832dacff63b7ab0bf765