### PR TITLE
Add close-after-script option

### DIFF
--- a/StikJIT/JSSupport/RunJSView.swift
+++ b/StikJIT/JSSupport/RunJSView.swift
@@ -74,9 +74,15 @@ class RunJSViewModel: ObservableObject {
             if let exception = self.context?.exception {
                 self.logs.append(exception.debugDescription)
             }
-            
+
             self.logs.append("Script Execution Completed")
             self.logs.append("You are safe to close the PIP Window.")
+
+            if UserDefaults.standard.bool(forKey: "closeAfterScript") {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                    exit(0)
+                }
+            }
         }
     }
 }

--- a/StikJIT/Views/HomeView.swift
+++ b/StikJIT/Views/HomeView.swift
@@ -43,6 +43,7 @@ struct HomeView: View {
 
     @AppStorage("useDefaultScript") private var useDefaultScript = false
     @AppStorage("enablePiP") private var enablePiP = true
+    @AppStorage("closeAfterScript") private var closeAfterScript = false
     @State var scriptViewShow = false
     @AppStorage("DefaultScriptName") var selectedScript = "attachDetach.js"
     @State var jsModel: RunJSViewModel?

--- a/StikJIT/Views/SettingsView.swift
+++ b/StikJIT/Views/SettingsView.swift
@@ -14,6 +14,7 @@ struct SettingsView: View {
     @AppStorage("useDefaultScript") private var useDefaultScript = false
     @AppStorage("enableAdvancedOptions") private var enableAdvancedOptions = false
     @AppStorage("enablePiP") private var enablePiP = true
+    @AppStorage("closeAfterScript") private var closeAfterScript = false
 
     @State private var isShowingPairingFilePicker = false
     @Environment(\.colorScheme) private var colorScheme
@@ -284,6 +285,9 @@ struct SettingsView: View {
                                                    Toggle("Picture in Picture", isOn: $enablePiP)
                                                        .foregroundColor(.primary)
                                                        .padding(.vertical, 6)
+                                                   Toggle("Close App After Running Script", isOn: $closeAfterScript)
+                                                       .foregroundColor(.primary)
+                                                       .padding(.vertical, 6)
                                                }
                                            }
                                            .padding(.vertical, 20)
@@ -292,6 +296,7 @@ struct SettingsView: View {
                                                if !newValue {
                                                    useDefaultScript = false
                                                    enablePiP = false
+                                                   closeAfterScript = false
                                                }
                                            }
                                        }


### PR DESCRIPTION
## Summary
- add new `closeAfterScript` option in Settings
- allow toggling close-after-script along with other advanced options
- exit the app after executing a script when `closeAfterScript` is enabled

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_6874564f4a28832da7f633a78888bd39