### PR TITLE
Fix applist error handling

### DIFF
--- a/StikJIT/StikJITApp.swift
+++ b/StikJIT/StikJITApp.swift
@@ -794,7 +794,8 @@ func isPairing() -> Bool {
     var pairingFile: IdevicePairingFile?
     let err = idevice_pairing_file_read(pairingpath, &pairingFile)
     if let err {
-        print("Failed to read pairing file: \(err.pointee.code)")
+        print("Failed to read pairing file: \(err.pointee.code) - \(String(cString: err.pointee.message))")
+        idevice_error_free(err)
         if err.pointee.code == -9 {  // InvalidHostID is -9
             return false
         }

--- a/StikJIT/Utilities/mountDDI.swift
+++ b/StikJIT/Utilities/mountDDI.swift
@@ -64,7 +64,8 @@ func isMounted() -> Bool {
     var pairingFile: IdevicePairingFile?
     let err = idevice_pairing_file_read(pairingFilePath, &pairingFile)
     if let err {
-        print("Failed to read pairing file: \(err)")
+        print("Failed to read pairing file: \(err.pointee.code) - \(String(cString: err.pointee.message))")
+        idevice_error_free(err)
         return false
     }
 
@@ -72,7 +73,8 @@ func isMounted() -> Bool {
     var provider: TcpProviderHandle?
     let providerError = idevice_tcp_provider_new(sockaddrPointer, pairingFile, "ImageMounterTest", &provider)
     if let providerError {
-        print("Failed to create TCP provider: \(providerError)")
+        print("Failed to create TCP provider: \(providerError.pointee.code) - \(String(cString: providerError.pointee.message))")
+        idevice_error_free(providerError)
         return false
     }
 
@@ -80,7 +82,8 @@ func isMounted() -> Bool {
     var client: ImageMounterHandle?
     let connectError = image_mounter_connect(provider, &client)
     if let connectError {
-        print("Failed to connect to image mounter: \(connectError)")
+        print("Failed to connect to image mounter: \(connectError.pointee.code) - \(String(cString: connectError.pointee.message))")
+        idevice_error_free(connectError)
         return false
     }
     idevice_provider_free(provider)
@@ -110,7 +113,8 @@ func isMounted() -> Bool {
         image_mounter_free(client)
         return devices.count != 0
     } else {
-        print("Failed to get device list: \(listError)")
+        print("Failed to get device list: \(listError!.pointee.code) - \(String(cString: listError!.pointee.message))")
+        idevice_error_free(listError)
         return false
     }
 }
@@ -141,7 +145,8 @@ func mountPersonalDDI(deviceIP: String = "10.7.0.1", imagePath: String, trustcac
     var pairingFile: IdevicePairingFile?
     let err = idevice_pairing_file_read(pairingFilePath.cString(using: .utf8), &pairingFile)
     if let err {
-        print("Failed to read pairing file: \(err.pointee.code)")
+        print("Failed to read pairing file: \(err.pointee.code) - \(String(cString: err.pointee.message))")
+        idevice_error_free(err)
         return 3 // EC: 3
     }
 
@@ -149,7 +154,8 @@ func mountPersonalDDI(deviceIP: String = "10.7.0.1", imagePath: String, trustcac
     var provider: TcpProviderHandle?
     let providerError = idevice_tcp_provider_new(sockaddrPointer, pairingFile, "ImageMounterTest".cString(using: .utf8), &provider)
     if let providerError {
-        print("Failed to create TCP provider: \(providerError)")
+        print("Failed to create TCP provider: \(providerError.pointee.code) - \(String(cString: providerError.pointee.message))")
+        idevice_error_free(providerError)
         return 4 // EC: 4
     }
     
@@ -157,24 +163,28 @@ func mountPersonalDDI(deviceIP: String = "10.7.0.1", imagePath: String, trustcac
     var pairingFile2: IdevicePairingFile?
     let P2err = idevice_pairing_file_read(pairingFilePath.cString(using: .utf8), &pairingFile2)
     if let P2err {
-        print("Failed to read pairing file: \(P2err.pointee.code)")
+        print("Failed to read pairing file: \(P2err.pointee.code) - \(String(cString: P2err.pointee.message))")
+        idevice_error_free(P2err)
         return 5 // EC: 5
     }
     
     var lockdownClient: LockdowndClientHandle?
     if let err = lockdownd_connect(provider, &lockdownClient) {
-        print("Failed to connect to lockdownd")
+        print("Failed to connect to lockdownd: \(err.pointee.code) - \(String(cString: err.pointee.message))")
+        idevice_error_free(err)
         return 6 // EC: 6
     }
     
     if let err = lockdownd_start_session(lockdownClient, pairingFile2) {
-        print("Failed to start session")
+        print("Failed to start session: \(err.pointee.code) - \(String(cString: err.pointee.message))")
+        idevice_error_free(err)
         return 7 // EC: 7
     }
     
     var uniqueChipIDPlist: plist_t?
     if let err = lockdownd_get_value(lockdownClient, "UniqueChipID".cString(using: .utf8), nil, &uniqueChipIDPlist) {
-        print("Failed to get UniqueChipID")
+        print("Failed to get UniqueChipID: \(err.pointee.code) - \(String(cString: err.pointee.message))")
+        idevice_error_free(err)
         return 8 // EC: 8
     }
     
@@ -186,7 +196,8 @@ func mountPersonalDDI(deviceIP: String = "10.7.0.1", imagePath: String, trustcac
     
     var mounterClient: ImageMounterHandle?
     if let err = image_mounter_connect(provider, &mounterClient) {
-        print("Failed to connect to image mounter")
+        print("Failed to connect to image mounter: \(err.pointee.code) - \(String(cString: err.pointee.message))")
+        idevice_error_free(err)
         return 9 // EC: 9
     }
     
@@ -208,6 +219,10 @@ func mountPersonalDDI(deviceIP: String = "10.7.0.1", imagePath: String, trustcac
             }
         }
     }
-    
-    return Int(result?.pointee.code ?? -1)
+
+    let code = Int(result?.pointee.code ?? -1)
+    if let result {
+        idevice_error_free(result)
+    }
+    return code
 }

--- a/StikJIT/idevice/JITEnableContext.m
+++ b/StikJIT/idevice/JITEnableContext.m
@@ -83,6 +83,7 @@ JITEnableContext* sharedJITContext = nil;
     IdeviceFfiError* err = idevice_pairing_file_read(pairingFileURL.fileSystemRepresentation, &pairingFile);
     if (err) {
         *error = [self errorWithStr:@"Failed to read pairing file!" code:err->code];
+        idevice_error_free(err);
         return nil;
     }
     return pairingFile;

--- a/StikJIT/idevice/applist.m
+++ b/StikJIT/idevice/applist.m
@@ -13,16 +13,22 @@
 
 NSDictionary<NSString*, NSString*>* list_installed_apps(IdeviceProviderHandle* provider, NSString** error) {
     InstallationProxyClientHandle *client = NULL;
-    if (installation_proxy_connect_tcp(provider, &client)) {
-        *error = @"Failed to connect to installation proxy";
+    IdeviceFfiError *err = installation_proxy_connect_tcp(provider, &client);
+    if (err) {
+        *error = [NSString stringWithFormat:@"Failed to connect to installation proxy: (%d) %s",
+                                           err->code, err->message];
+        idevice_error_free(err);
         return nil;
     }
 
     void *apps = NULL;
     size_t count = 0;
-    if (installation_proxy_get_apps(client, "User", NULL, 0, &apps, &count)) {
+    err = installation_proxy_get_apps(client, "User", NULL, 0, &apps, &count);
+    if (err) {
         installation_proxy_client_free(client);
-        *error = @"Failed to get apps";
+        *error = [NSString stringWithFormat:@"Failed to get apps: (%d) %s",
+                                          err->code, err->message];
+        idevice_error_free(err);
         return nil;
     }
 
@@ -72,16 +78,22 @@ NSDictionary<NSString*, NSString*>* list_installed_apps(IdeviceProviderHandle* p
 
 UIImage* getAppIcon(IdeviceProviderHandle* provider, NSString* bundleID, NSString** error) {
     SpringBoardServicesClientHandle *client = NULL;
-    if (springboard_services_connect(provider, &client)) {
-        *error = @"Failed to connect to SpringBoard Services";
+    IdeviceFfiError *err = springboard_services_connect(provider, &client);
+    if (err) {
+        *error = [NSString stringWithFormat:@"Failed to connect to SpringBoard Services: (%d) %s",
+                                           err->code, err->message];
+        idevice_error_free(err);
         return nil;
     }
 
     void *pngData = NULL;
     size_t dataLen = 0;
-    if (springboard_services_get_icon(client, [bundleID UTF8String], &pngData, &dataLen)) {
+    err = springboard_services_get_icon(client, [bundleID UTF8String], &pngData, &dataLen);
+    if (err) {
         springboard_services_free(client);
-        *error = @"Failed to get app icon";
+        *error = [NSString stringWithFormat:@"Failed to get app icon: (%d) %s",
+                                          err->code, err->message];
+        idevice_error_free(err);
         return nil;
     }
 

--- a/StikJIT/idevice/jit.c
+++ b/StikJIT/idevice/jit.c
@@ -26,7 +26,12 @@ void runDebugServerCommand(int pid, DebugProxyHandle* debug_proxy, LogFuncC logg
     DebugserverCommandHandle *disableAckCommand = debugserver_command_new("QStartNoAckMode", NULL, 0);
     IdeviceFfiError* err = debug_proxy_send_command(debug_proxy, disableAckCommand, &disableResponse);
     debugserver_command_free(disableAckCommand);
-    logger("QStartNoAckMode result = %s, err = %d", disableResponse, err);
+    if (err) {
+        logger("QStartNoAckMode failed: (%d) %s", err->code, err->message);
+        idevice_error_free(err);
+    } else {
+        logger("QStartNoAckMode result = %s", disableResponse);
+    }
     idevice_string_free(disableResponse);
     debug_proxy_set_ack_mode(debug_proxy, false);
     
@@ -35,6 +40,10 @@ void runDebugServerCommand(int pid, DebugProxyHandle* debug_proxy, LogFuncC logg
         callback(pid, debug_proxy, semaphore);
         dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
         err = debug_proxy_send_raw(debug_proxy, "\x03", 1);
+        if (err) {
+            logger("Failed to send break: (%d) %s", err->code, err->message);
+            idevice_error_free(err);
+        }
         usleep(500);
     } else {
         // Send vAttach command with PID in hex
@@ -52,7 +61,8 @@ void runDebugServerCommand(int pid, DebugProxyHandle* debug_proxy, LogFuncC logg
         debugserver_command_free(attach_cmd);
         
         if (err) {
-            logger("Failed to attach to process: %d", err);
+            logger("Failed to attach to process: (%d) %s", err->code, err->message);
+            idevice_error_free(err);
         } else if (attach_response != NULL) {
             logger("Attach response: %s", attach_response);
             idevice_string_free(attach_response);
@@ -70,7 +80,7 @@ void runDebugServerCommand(int pid, DebugProxyHandle* debug_proxy, LogFuncC logg
         debugserver_command_free(detach_cmd);
         
         if (err) {
-            logger("Failed to detach from process: %d", err->code);
+            logger("Failed to detach from process: (%d) %s", err->code, err->message);
             idevice_error_free(err);
         } else if (detach_response != NULL) {
             logger("Detach response: %s", detach_response);


### PR DESCRIPTION
## Summary
- use `IdeviceFfiError` results for Installation Proxy and SpringBoard Services
- improved error cleanup across other parts of the app

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_687aa9a4bd1c832d91d9b36a29e73b5b