### PR TITLE
Fixes idevice_pair download link

### DIFF
--- a/routes/download.html
+++ b/routes/download.html
@@ -80,17 +80,17 @@
               <p>StikDebug requires a pairing file to function properly. Download <code>idevice pair</code> for your platform and follow the instructions below:</p>
               
               <div class="download-platforms">
-                <a href="https://github.com/jkcoxson/idevice_pair/releases/latest/download/iDevicePair--macos-universal.dmg" class="platform-link">
+                <a href="https://github.com/jkcoxson/idevice_pair/releases/latest/download/idevice_pair--macos-universal.dmg" class="platform-link">
                   <span class="platform-icon macos"></span>
                   <span>macOS</span>
                 </a>
-                <a href="https://github.com/jkcoxson/idevice_pair/releases/latest/download/iDevicePair--windows-x86_64.exe" class="platform-link">
+                <a href="https://github.com/jkcoxson/idevice_pair/releases/latest/download/idevice_pair--windows-x86_64.exe" class="platform-link">
                   <span class="platform-icon windows"></span>
                   <span>Windows</span>
                 </a>
-                <a href="https://github.com/jkcoxson/idevice_pair/releases/latest/download/iDevicePair--linux-x86_64.AppImage" class="platform-link">
+                <a href="https://github.com/jkcoxson/idevice_pair/releases/latest/download/idevice_pair--linux-x86_64.AppImage" class="platform-link">
                   <span class="platform-icon linux"></span>
-                  <span>Linux</span>
+                  <span>Linux (x84_64)</span>
                 </a>
               </div>
             </div>
@@ -102,10 +102,10 @@
         <div class="platform-section">
           <h3>For macOS</h3>
           <ol>
-            <li>Download <code>iDevicePair--macos-universal.dmg</code>. Open the file and drag <code>idevice pair</code> to <code>Applications</code>.</li>
+            <li>Download <code>idevice_pair--macos-universal.dmg</code>. Open the file and drag <code>idevice pair</code> to <code>Applications</code>.</li>
             <li>Connect your secondary device to your computer via cable. If a prompt appears, tap <code>trust</code> and type in your passcode.</li>
             <li>Unlock your device, then open <code>idevice pair</code> and select your device in the drop-down menu.</li>
-            <li>Ensure your device is unlocked and opened to the home screen, then select <code>generate</code> (If already using an app such as SideStore which also utilizes a pairing file, select <code>load</code> instead). When a prompt appears on your device, tap <code>trust</code>. Your pairing file should appear.</li>
+            <li>Ensure your device is unlocked and opened to the home screen, then select <code>load</code>. When a prompt appears on your device, tap <code>trust</code>. Your pairing file should appear.</li>
             <li>Ensure your device is still open to the home screen, then scroll down to the StikDebug section and select <code>install</code>. The word "success" should appear in green.</li>
           </ol>
         </div>
@@ -116,10 +116,10 @@
           <h3>For Windows</h3>
           <ol>
             <li>Install iTunes from Apple's website <a href="https://apple.com/itunes/download/win64" target="_blank">here</a> (not the Microsoft Store).</li>
-            <li>Download <code>iDevicePair--windows-x86_64.exe</code> (move it somewhere you won't lose it).</li>
+            <li>Download <code>idevice_pair--windows-x86_64.exe</code> (move it somewhere you won't lose it).</li>
             <li>Connect your secondary device to your computer via cable. If a prompt appears, tap <code>trust</code> and type in your passcode.</li>
             <li>Unlock your device, then, in File Explorer, open <code>idevice pair</code> and select your device in the drop-down menu.</li>
-            <li>Ensure your device is unlocked and opened to the home screen, then select <code>generate</code> (If already using an app such as SideStore which also utilizes a pairing file, select <code>load</code> instead). When a prompt appears on your device, tap <code>trust</code>. Your pairing file should appear.</li>
+            <li>Ensure your device is unlocked and opened to the home screen, then select <code>load</code>. When a prompt appears on your device, tap <code>trust</code>. Your pairing file should appear.</li>
             <li>Ensure your device is still open to the home screen, then scroll down to the StikDebug section and select <code>install</code>. The word "success" should appear in green.</li>
           </ol>
         </div>
@@ -132,10 +132,10 @@
             <li>In the Linux terminal, run the following command to install usbmuxd:
               <pre>sudo apt install -y usbmuxd</pre>
             </li>
-            <li>Download <code>iDevicePair--linux-x86_64.AppImage</code> and make it executable.</li>
+            <li>Download <code>idevice_pair--linux-x86_64.AppImage</code> and make it executable.</li>
             <li>Connect your secondary device to your computer via cable. If a prompt appears, tap <code>trust</code> and type in your passcode.</li>
             <li>Unlock your device, then execute <code>idevice pair</code> and select your device in the drop-down menu.</li>
-            <li>Ensure your device is unlocked and opened to the home screen, then select <code>generate</code> (If already using an app such as SideStore which also utilizes a pairing file, select <code>load</code> instead). When a prompt appears on your device, tap <code>trust</code>. Your pairing file should appear.</li>
+            <li>Ensure your device is unlocked and opened to the home screen, then select <code>load</code>. When a prompt appears on your device, tap <code>trust</code>. Your pairing file should appear.</li>
             <li>Ensure your device is still open to the home screen, then scroll down to the StikDebug section and select <code>install</code>. The word "success" should appear in green.</li>
           </ol>
         </div>


### PR DESCRIPTION
Also switches “generate” to “load”. I’m planning a bigger update for this guide later but we’ll see if its approved [here](https://github.com/StephenDev0/StikDebug-Guide/pull/10) first and I don’t want to do any more html tonight.