### PR TITLE
chore: remove zsign package

### DIFF
--- a/StikDebug.xcodeproj/project.pbxproj
+++ b/StikDebug.xcodeproj/project.pbxproj
@@ -8,7 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		17C744F02E20BED000834F17 /* Pipify in Frameworks */ = {isa = PBXBuildFile; productRef = 17C744EF2E20BED000834F17 /* Pipify */; };
-		6874D2722E6B4A5E00B18184 /* ZSignApple in Frameworks */ = {isa = PBXBuildFile; productRef = 6874D2712E6B4A5E00B18184 /* ZSignApple */; };
 		68D569BE2E1B415700A5BA36 /* CodeEditorView in Frameworks */ = {isa = PBXBuildFile; productRef = 68D569BD2E1B415700A5BA36 /* CodeEditorView */; };
 		68D569C02E1B415700A5BA36 /* LanguageSupport in Frameworks */ = {isa = PBXBuildFile; productRef = 68D569BF2E1B415700A5BA36 /* LanguageSupport */; };
 		68E714E62E6AA2B00025610F /* ZIPFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = 68E714E52E6AA2B00025610F /* ZIPFoundation */; };
@@ -158,7 +157,6 @@
 				68D569C02E1B415700A5BA36 /* LanguageSupport in Frameworks */,
 				68D569BE2E1B415700A5BA36 /* CodeEditorView in Frameworks */,
 				68E714E62E6AA2B00025610F /* ZIPFoundation in Frameworks */,
-				6874D2722E6B4A5E00B18184 /* ZSignApple in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -273,7 +271,6 @@
 				17C744EF2E20BED000834F17 /* Pipify */,
 				DCBA85852E3897BD00E88C06 /* StikImporter */,
 				68E714E52E6AA2B00025610F /* ZIPFoundation */,
-				6874D2712E6B4A5E00B18184 /* ZSignApple */,
 			);
 			productName = StikJIT;
 			productReference = DC6F1D372D94EADD0071B2B6 /* StikDebug.app */;
@@ -391,7 +388,6 @@
 				68D569BC2E1B415700A5BA36 /* XCRemoteSwiftPackageReference "CodeEditorView" */,
 				17C744EE2E20BED000834F17 /* XCRemoteSwiftPackageReference "swiftui-pipify" */,
 				DCBA85842E3897BD00E88C06 /* XCRemoteSwiftPackageReference "StikImporter" */,
-				68CB05252E6AA15F0075BAA9 /* XCRemoteSwiftPackageReference "zsign-ios" */,
 				68E714E42E6AA2B00025610F /* XCRemoteSwiftPackageReference "ZIPFoundation" */,
 			);
 			preferredProjectObjectVersion = 77;
@@ -1003,14 +999,6 @@
 				kind = branch;
 			};
 		};
-		68CB05252E6AA15F0075BAA9 /* XCRemoteSwiftPackageReference "zsign-ios" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/zwsn/zsign-ios";
-			requirement = {
-				branch = main;
-				kind = branch;
-			};
-		};
 		68D569BC2E1B415700A5BA36 /* XCRemoteSwiftPackageReference "CodeEditorView" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/mchakravarty/CodeEditorView";
@@ -1042,10 +1030,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 17C744EE2E20BED000834F17 /* XCRemoteSwiftPackageReference "swiftui-pipify" */;
 			productName = Pipify;
-		};
-		6874D2712E6B4A5E00B18184 /* ZSignApple */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = ZSignApple;
 		};
 		68D569BD2E1B415700A5BA36 /* CodeEditorView */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/StikDebug.xcodeproj/project.pbxproj
+++ b/StikDebug.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		17C744F02E20BED000834F17 /* Pipify in Frameworks */ = {isa = PBXBuildFile; productRef = 17C744EF2E20BED000834F17 /* Pipify */; };
+		68AD80462E6B65DA00DE9112 /* ZsignSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 68AD80452E6B65DA00DE9112 /* ZsignSwift */; };
+		68AD80482E6B65DA00DE9112 /* zsign in Frameworks */ = {isa = PBXBuildFile; productRef = 68AD80472E6B65DA00DE9112 /* zsign */; };
 		68D569BE2E1B415700A5BA36 /* CodeEditorView in Frameworks */ = {isa = PBXBuildFile; productRef = 68D569BD2E1B415700A5BA36 /* CodeEditorView */; };
 		68D569C02E1B415700A5BA36 /* LanguageSupport in Frameworks */ = {isa = PBXBuildFile; productRef = 68D569BF2E1B415700A5BA36 /* LanguageSupport */; };
 		68E714E62E6AA2B00025610F /* ZIPFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = 68E714E52E6AA2B00025610F /* ZIPFoundation */; };
@@ -154,6 +156,8 @@
 			files = (
 				DCBA85862E3897BD00E88C06 /* StikImporter in Frameworks */,
 				17C744F02E20BED000834F17 /* Pipify in Frameworks */,
+				68AD80462E6B65DA00DE9112 /* ZsignSwift in Frameworks */,
+				68AD80482E6B65DA00DE9112 /* zsign in Frameworks */,
 				68D569C02E1B415700A5BA36 /* LanguageSupport in Frameworks */,
 				68D569BE2E1B415700A5BA36 /* CodeEditorView in Frameworks */,
 				68E714E62E6AA2B00025610F /* ZIPFoundation in Frameworks */,
@@ -271,6 +275,8 @@
 				17C744EF2E20BED000834F17 /* Pipify */,
 				DCBA85852E3897BD00E88C06 /* StikImporter */,
 				68E714E52E6AA2B00025610F /* ZIPFoundation */,
+				68AD80452E6B65DA00DE9112 /* ZsignSwift */,
+				68AD80472E6B65DA00DE9112 /* zsign */,
 			);
 			productName = StikJIT;
 			productReference = DC6F1D372D94EADD0071B2B6 /* StikDebug.app */;
@@ -389,6 +395,7 @@
 				17C744EE2E20BED000834F17 /* XCRemoteSwiftPackageReference "swiftui-pipify" */,
 				DCBA85842E3897BD00E88C06 /* XCRemoteSwiftPackageReference "StikImporter" */,
 				68E714E42E6AA2B00025610F /* XCRemoteSwiftPackageReference "ZIPFoundation" */,
+				68AD80442E6B65DA00DE9112 /* XCRemoteSwiftPackageReference "Zsign-Package" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = DC6F1D382D94EADD0071B2B6 /* Products */;
@@ -999,6 +1006,14 @@
 				kind = branch;
 			};
 		};
+		68AD80442E6B65DA00DE9112 /* XCRemoteSwiftPackageReference "Zsign-Package" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/khcrysalis/Zsign-Package/";
+			requirement = {
+				branch = package;
+				kind = branch;
+			};
+		};
 		68D569BC2E1B415700A5BA36 /* XCRemoteSwiftPackageReference "CodeEditorView" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/mchakravarty/CodeEditorView";
@@ -1030,6 +1045,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 17C744EE2E20BED000834F17 /* XCRemoteSwiftPackageReference "swiftui-pipify" */;
 			productName = Pipify;
+		};
+		68AD80452E6B65DA00DE9112 /* ZsignSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 68AD80442E6B65DA00DE9112 /* XCRemoteSwiftPackageReference "Zsign-Package" */;
+			productName = ZsignSwift;
+		};
+		68AD80472E6B65DA00DE9112 /* zsign */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 68AD80442E6B65DA00DE9112 /* XCRemoteSwiftPackageReference "Zsign-Package" */;
+			productName = zsign;
 		};
 		68D569BD2E1B415700A5BA36 /* CodeEditorView */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/StikDebug.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/StikDebug.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "fd6a0b1431f87fb1abbacc56899d6160059dfd4b59e9d381af1131363e73fb23",
+  "originHash" : "01d0d47170e97de76701ab09eade5c2be88cf1d0ab755275f6cb2c56fe6d123c",
   "pins" : [
     {
       "identity" : "codeeditorview",
@@ -8,6 +8,15 @@
       "state" : {
         "revision" : "aba6c189bb2f6fd9d7b8e9f5739aeb3c8c7e3254",
         "version" : "0.15.4"
+      }
+    },
+    {
+      "identity" : "openssl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/krzyzanowskim/OpenSSL",
+      "state" : {
+        "revision" : "623c84da314e85363236507ca38a4bde65df21c3",
+        "version" : "3.3.3001"
       }
     },
     {
@@ -44,6 +53,15 @@
       "state" : {
         "revision" : "02b6abe5f6eef7e3cbd5f247c5cc24e246efcfe0",
         "version" : "0.9.19"
+      }
+    },
+    {
+      "identity" : "zsign-package",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/khcrysalis/Zsign-Package/",
+      "state" : {
+        "branch" : "package",
+        "revision" : "6ffe703df73ef9069adacdbb19d571f11a69a801"
       }
     }
   ],

--- a/StikDebug.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/StikDebug.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -45,15 +45,6 @@
         "revision" : "02b6abe5f6eef7e3cbd5f247c5cc24e246efcfe0",
         "version" : "0.9.19"
       }
-    },
-    {
-      "identity" : "zsign-ios",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/zwsn/zsign-ios",
-      "state" : {
-        "branch" : "main",
-        "revision" : "a7f275fb4830ea48adf536fcddee7d05471970d0"
-      }
     }
   ],
   "version" : 3

--- a/StikJIT/Views/Testing.swift
+++ b/StikJIT/Views/Testing.swift
@@ -364,16 +364,6 @@ final class AppSignerManager: ObservableObject {
                     try? FileManager.default.copyItem(at: icon1024URL, to: previewDest)
                 }
                 
-                let pw = KeychainHelper.shared.readPassword(forKey: cert.id.uuidString) ?? ""
-                let rc = zsign(appFolder.path,
-                               cert.p12URL.path,
-                               cert.p12URL.path,
-                               cert.mobURL?.path ?? "",
-                               pw, "", "")
-                guard rc == 0 else {
-                    throw NSError(domain: "zsign", code: Int(rc),
-                                  userInfo: [NSLocalizedDescriptionKey: "zsign returned \(rc)"])
-                }
                 
                 let outDir = docs.appendingPathComponent("SignedApps/\(newName)", isDirectory: true)
                 if FileManager.default.fileExists(atPath: outDir.path) { try FileManager.default.removeItem(at: outDir) }


### PR DESCRIPTION
## Summary
- remove zsign Swift package and all project references
- drop zsign-based signing step

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2b984dec832d99e2876b534262a5