### PR TITLE
Add light mode support for default theme

### DIFF
--- a/StikJIT/JSSupport/ScriptListView.swift
+++ b/StikJIT/JSSupport/ScriptListView.swift
@@ -38,6 +38,7 @@ struct ScriptListView: View {
     
     @AppStorage("appTheme") private var appThemeRaw: String = AppTheme.system.rawValue
     @Environment(\.themeExpansionManager) private var themeExpansion
+    @Environment(\.colorScheme) private var colorScheme
     private var backgroundStyle: BackgroundStyle { themeExpansion?.backgroundStyle(for: appThemeRaw) ?? AppTheme.system.backgroundStyle }
     private var preferredScheme: ColorScheme? { themeExpansion?.preferredColorScheme(for: appThemeRaw) }
 
@@ -285,6 +286,8 @@ struct ScriptListView: View {
             colors = background.isEmpty ? [particle, particle.opacity(0.4)] : background
         case .customGradient(let palette):
             colors = palette
+        case .adaptiveGradient(let light, let dark):
+            colors = colorScheme == .dark ? dark : light
         }
         if colors.count >= 2 { return colors }
         if let first = colors.first { return [first, first.opacity(0.6)] }

--- a/StikJIT/Utilities/AppTheme.swift
+++ b/StikJIT/Utilities/AppTheme.swift
@@ -43,8 +43,7 @@ enum AppTheme: String, CaseIterable, Identifiable {
     var preferredColorScheme: ColorScheme? {
         switch self {
         case .system:
-            // Make the default theme use a dark appearance to match Obsidian.
-            return .dark
+            return nil
         case .sunset, .forest:
             return nil
         case .darkStatic, .neonAnimated, .blobs, .particles, .aurora, .ocean, .midnight, .cyberwave:
@@ -55,8 +54,8 @@ enum AppTheme: String, CaseIterable, Identifiable {
     var backgroundStyle: BackgroundStyle {
         switch self {
         case .system:
-            // Make the default theme render with the Obsidian gradient.
-            return .staticGradient(colors: Palette.obsidianGradient)
+            return .adaptiveGradient(light: Palette.systemLightGradient,
+                                     dark: Palette.systemDarkGradient)
         case .darkStatic:
             return .staticGradient(colors: Palette.obsidianGradient)
         case .neonAnimated:
@@ -89,10 +88,13 @@ enum BackgroundStyle: Equatable {
     case blobs(colors: [Color], background: [Color])
     case particles(particle: Color, background: [Color])
     case customGradient(colors: [Color])
+    case adaptiveGradient(light: [Color], dark: [Color])
 }
 
 private struct Palette {
     static let defaultGradient = hexColors("#1C1F3A", "#3E4C7C", "#1F1C2C")
+    static let systemLightGradient = hexColors("#F6F8FF", "#E3ECFF", "#F0F4FF")
+    static let systemDarkGradient = obsidianGradient
     static let obsidianGradient = hexColors("#000000", "#1C1C1C", "#262626")
     static let neon = hexColors("#00F5A0", "#00D9F5", "#C96BFF")
     static let hazeBlobs = hexColors("#FF8BA7", "#A98BFF", "#70C8FF", "#67FFDA")
@@ -126,7 +128,8 @@ private func staticGradientView(colors: [Color]) -> some View {
 struct ThemedBackground: View {
     let style: BackgroundStyle
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    
+    @Environment(\.colorScheme) private var colorScheme
+
     var body: some View {
         Group {
             switch style {
@@ -155,6 +158,10 @@ struct ThemedBackground: View {
                     ParticleFieldBackground(particleColor: particle, backgroundColors: background.ensureMinimumCount())
                 }
             case .customGradient(let colors):
+                staticGradientView(colors: colors)
+                    .ignoresSafeArea()
+            case .adaptiveGradient(let light, let dark):
+                let colors = colorScheme == .dark ? dark : light
                 staticGradientView(colors: colors)
                     .ignoresSafeArea()
             }

--- a/StikJIT/Views/DisplayView.swift
+++ b/StikJIT/Views/DisplayView.swift
@@ -740,7 +740,9 @@ private struct ThemePreviewCard: View {
     let selected: Bool
     let action: () -> Void
     var staticPreview: Bool = false
-    
+
+    @Environment(\.colorScheme) private var colorScheme
+
     private func staticized(_ style: BackgroundStyle) -> BackgroundStyle {
         switch style {
         case .staticGradient(let colors):
@@ -755,6 +757,9 @@ private struct ThemePreviewCard: View {
             return .staticGradient(colors: background)
         case .customGradient(let colors):
             return .customGradient(colors: colors)
+        case .adaptiveGradient(let light, let dark):
+            let colors = colorScheme == .dark ? dark : light
+            return .staticGradient(colors: colors)
         }
     }
     

--- a/StikJIT/Views/InstalledAppsListView.swift
+++ b/StikJIT/Views/InstalledAppsListView.swift
@@ -1094,6 +1094,7 @@ private struct ThemedRowBackground: View {
     var performanceMode: Bool
     var style: BackgroundStyle
     var cornerRadius: CGFloat
+    @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
         let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
@@ -1149,6 +1150,17 @@ private struct ThemedRowBackground: View {
                 .opacity(0.40)
         case .particles(let particle, _):
             shape.fill(particle.opacity(0.18))
+        case .adaptiveGradient(let light, let dark):
+            let palette = colorScheme == .dark ? dark : light
+            shape
+                .fill(
+                    LinearGradient(
+                        gradient: Gradient(colors: normalized(palette)),
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+                .opacity(0.32)
         }
     }
 


### PR DESCRIPTION
## Summary
- allow the default theme to follow the system appearance and render different gradients for light and dark mode
- add an adaptive gradient background style and propagate it through previews and row backgrounds
- ensure lists and glass overlays pick the appropriate colors for the selected appearance

## Testing
- not run (iOS project without command line test target)

------
https://chatgpt.com/codex/tasks/task_e_68d57a6671a0832d82db0a8083f1f9c4