### PR TITLE
Add TXM override setting for script execution

### DIFF
--- a/StikJIT/StikJITApp.swift
+++ b/StikJIT/StikJITApp.swift
@@ -17,6 +17,7 @@ private func registerAdvancedOptionsDefault() {
     let enabled = os.majorVersion >= 19
     UserDefaults.standard.register(defaults: ["enableAdvancedOptions": enabled])
     UserDefaults.standard.register(defaults: ["enablePiP": enabled])
+    UserDefaults.standard.register(defaults: [UserDefaults.Keys.txmOverride: false])
 }
 
 // MARK: - Welcome Sheet

--- a/StikJIT/Utilities/Extensions.swift
+++ b/StikJIT/Utilities/Extensions.swift
@@ -18,3 +18,10 @@ extension UIDocumentPickerViewController {
         return fix_init(forOpeningContentTypes: contentTypes, asCopy: true)
     }
 }
+
+extension UserDefaults {
+    enum Keys {
+        /// Forces the app to treat the current device as TXM-capable so scripts always run.
+        static let txmOverride = "overrideTXMForScripts"
+    }
+}

--- a/StikJIT/Views/HomeView.swift
+++ b/StikJIT/Views/HomeView.swift
@@ -1656,7 +1656,11 @@ private struct ConnectByPIDSheet: View {
 
 public extension ProcessInfo {
     var hasTXM: Bool {
-        {
+        if isTXMOverridden {
+            return true
+        }
+
+        return {
             if let boot = FileManager.default.filePath(atPath: "/System/Volumes/Preboot", withLength: 36),
                let file = FileManager.default.filePath(atPath: "\(boot)/boot", withLength: 96) {
                 return access("\(file)/usr/standalone/firmware/FUD/Ap,TrustedExecutionMonitor.img4", F_OK) == 0
@@ -1666,5 +1670,9 @@ public extension ProcessInfo {
                 }) ?? false
             }
         }()
+    }
+
+    var isTXMOverridden: Bool {
+        UserDefaults.standard.bool(forKey: UserDefaults.Keys.txmOverride)
     }
 }

--- a/StikJIT/Views/SettingsView.swift
+++ b/StikJIT/Views/SettingsView.swift
@@ -15,6 +15,7 @@ struct SettingsView: View {
     @AppStorage("enableAdvancedBetaOptions") private var enableAdvancedBetaOptions = false
     @AppStorage("enableTesting") private var enableTesting = false
     @AppStorage("enablePiP") private var enablePiP = false
+    @AppStorage(UserDefaults.Keys.txmOverride) private var overrideTXMDetection = false
     @AppStorage("customAccentColor") private var customAccentColorHex: String = ""
     @AppStorage("appTheme") private var appThemeRaw: String = AppTheme.system.rawValue
     @Environment(\.themeExpansionManager) private var themeExpansion
@@ -328,11 +329,22 @@ struct SettingsView: View {
                 Text("Behavior")
                     .font(.headline)
                     .foregroundColor(.primary)
-                
+
                 Toggle("Run Default Script After Connecting", isOn: $useDefaultScript)
                     .tint(accentColor)
                 Toggle("Picture in Picture", isOn: $enablePiP)
                     .tint(accentColor)
+                Toggle(isOn: $overrideTXMDetection) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Always Run Scripts")
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundColor(.primary.opacity(0.9))
+                        Text("Treat this device as TXM-capable to bypass hardware checks.")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
+                .tint(accentColor)
             }
             .onChange(of: enableAdvancedOptions) { _, newValue in
                 if !newValue {
@@ -356,7 +368,7 @@ struct SettingsView: View {
                 Text("Advanced")
                     .font(.headline)
                     .foregroundColor(.primary)
-                
+
                 Button(action: { openAppFolder() }) {
                     HStack {
                         Image(systemName: "folder")
@@ -425,9 +437,15 @@ struct SettingsView: View {
             }
         }
     }
-    
+
     private var versionInfo: some View {
-        let txmLabel = ProcessInfo.processInfo.hasTXM ? "TXM" : "Non TXM"
+        let processInfo = ProcessInfo.processInfo
+        let txmLabel: String
+        if processInfo.isTXMOverridden {
+            txmLabel = "TXM (Override)"
+        } else {
+            txmLabel = processInfo.hasTXM ? "TXM" : "Non TXM"
+        }
         return HStack {
             Spacer()
             Text("Version \(appVersion) • iOS \(UIDevice.current.systemVersion) • \(txmLabel)")


### PR DESCRIPTION
## Summary
- add a shared UserDefaults key and default for the TXM override flag
- allow ProcessInfo.hasTXM to respect the override and expose its state
- surface an "Always Run Scripts" toggle in the main behavior settings card and annotate the version label when overridden

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d57c3372b0832d8c1186c519938c9e