### PR TITLE
Adopt BGContinuedProcessingTask for background execution

### DIFF
--- a/DebugWidget/DebugWidgetBundle.swift
+++ b/DebugWidget/DebugWidgetBundle.swift
@@ -11,7 +11,7 @@ import SwiftUI
 @main
 struct StikDebugWidgetBundle: WidgetBundle {
     var body: some Widget {
-        // Both widgets enabled: Favorites uses enable-jit URL scheme (with PiP/script handled in-app),
+        // Both widgets enabled: Favorites uses enable-jit URL scheme (with continued-processing handled in-app),
         // System Apps uses launch-app URL scheme for non-debug launch behavior.
         FavoritesWidget()
         SystemAppsWidget()

--- a/StikDebug.xcodeproj/project.pbxproj
+++ b/StikDebug.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		17C744F02E20BED000834F17 /* Pipify in Frameworks */ = {isa = PBXBuildFile; productRef = 17C744EF2E20BED000834F17 /* Pipify */; };
 		687843662E8765D1002D0813 /* ZSignApple in Frameworks */ = {isa = PBXBuildFile; productRef = 687843652E8765D1002D0813 /* ZSignApple */; };
 		68D1FA402E847E4A0028A0EA /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 68D1FA3F2E847E4A0028A0EA /* StoreKit.framework */; };
 		68D569BE2E1B415700A5BA36 /* CodeEditorView in Frameworks */ = {isa = PBXBuildFile; productRef = 68D569BD2E1B415700A5BA36 /* CodeEditorView */; };
@@ -156,7 +155,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				DCBA85862E3897BD00E88C06 /* StikImporter in Frameworks */,
-				17C744F02E20BED000834F17 /* Pipify in Frameworks */,
 				68D569C02E1B415700A5BA36 /* LanguageSupport in Frameworks */,
 				68D1FA402E847E4A0028A0EA /* StoreKit.framework in Frameworks */,
 				68D569BE2E1B415700A5BA36 /* CodeEditorView in Frameworks */,
@@ -274,7 +272,6 @@
 			packageProductDependencies = (
 				68D569BD2E1B415700A5BA36 /* CodeEditorView */,
 				68D569BF2E1B415700A5BA36 /* LanguageSupport */,
-				17C744EF2E20BED000834F17 /* Pipify */,
 				DCBA85852E3897BD00E88C06 /* StikImporter */,
 				68E714E52E6AA2B00025610F /* ZIPFoundation */,
 				687843652E8765D1002D0813 /* ZSignApple */,
@@ -393,7 +390,6 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				68D569BC2E1B415700A5BA36 /* XCRemoteSwiftPackageReference "CodeEditorView" */,
-				17C744EE2E20BED000834F17 /* XCRemoteSwiftPackageReference "swiftui-pipify" */,
 				DCBA85842E3897BD00E88C06 /* XCRemoteSwiftPackageReference "StikImporter" */,
 				68E714E42E6AA2B00025610F /* XCRemoteSwiftPackageReference "ZIPFoundation" */,
 				687843642E8765D0002D0813 /* XCRemoteSwiftPackageReference "zsign-swift" */,
@@ -999,14 +995,6 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		17C744EE2E20BED000834F17 /* XCRemoteSwiftPackageReference "swiftui-pipify" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/hugeBlack/swiftui-pipify";
-			requirement = {
-				branch = main;
-				kind = branch;
-			};
-		};
 		687843642E8765D0002D0813 /* XCRemoteSwiftPackageReference "zsign-swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/loyahdev/zsign-swift";
@@ -1042,11 +1030,6 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		17C744EF2E20BED000834F17 /* Pipify */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 17C744EE2E20BED000834F17 /* XCRemoteSwiftPackageReference "swiftui-pipify" */;
-			productName = Pipify;
-		};
 		687843652E8765D1002D0813 /* ZSignApple */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 687843642E8765D0002D0813 /* XCRemoteSwiftPackageReference "zsign-swift" */;

--- a/StikDebug.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/StikDebug.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,60 +1,51 @@
 {
-  "originHash" : "af465bb1c1430dc380451fa591e9921f0137b228028823dc223d9644e144d632",
-  "pins" : [
+  "originHash": "",
+  "pins": [
     {
-      "identity" : "codeeditorview",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mchakravarty/CodeEditorView",
-      "state" : {
-        "revision" : "aba6c189bb2f6fd9d7b8e9f5739aeb3c8c7e3254",
-        "version" : "0.15.4"
+      "identity": "codeeditorview",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/mchakravarty/CodeEditorView",
+      "state": {
+        "revision": "aba6c189bb2f6fd9d7b8e9f5739aeb3c8c7e3254",
+        "version": "0.15.4"
       }
     },
     {
-      "identity" : "rearrange",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ChimeHQ/Rearrange.git",
-      "state" : {
-        "revision" : "5ff7f3363f7a08f77e0d761e38e6add31c2136e1",
-        "version" : "1.8.1"
+      "identity": "rearrange",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/ChimeHQ/Rearrange.git",
+      "state": {
+        "revision": "5ff7f3363f7a08f77e0d761e38e6add31c2136e1",
+        "version": "1.8.1"
       }
     },
     {
-      "identity" : "stikimporter",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/StephenDev0/StikImporter",
-      "state" : {
-        "revision" : "4d80fca1334493889501d5b5a9fdcbb262e11f24",
-        "version" : "1.0.2"
+      "identity": "stikimporter",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/StephenDev0/StikImporter",
+      "state": {
+        "revision": "4d80fca1334493889501d5b5a9fdcbb262e11f24",
+        "version": "1.0.2"
       }
     },
     {
-      "identity" : "swiftui-pipify",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/hugeBlack/swiftui-pipify",
-      "state" : {
-        "branch" : "main",
-        "revision" : "a1ec2fd1781c8289bff1a8b3f664dcf21c910efb"
+      "identity": "zipfoundation",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/weichsel/ZIPFoundation",
+      "state": {
+        "revision": "02b6abe5f6eef7e3cbd5f247c5cc24e246efcfe0",
+        "version": "0.9.19"
       }
     },
     {
-      "identity" : "zipfoundation",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/weichsel/ZIPFoundation",
-      "state" : {
-        "revision" : "02b6abe5f6eef7e3cbd5f247c5cc24e246efcfe0",
-        "version" : "0.9.19"
-      }
-    },
-    {
-      "identity" : "zsign-swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/loyahdev/zsign-swift",
-      "state" : {
-        "branch" : "main",
-        "revision" : "574ad0bc993ecb2b13b170730bd5b196005034b4"
+      "identity": "zsign-swift",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/loyahdev/zsign-swift",
+      "state": {
+        "branch": "main",
+        "revision": "574ad0bc993ecb2b13b170730bd5b196005034b4"
       }
     }
   ],
-  "version" : 3
+  "version": 3
 }

--- a/StikJIT/Info.plist
+++ b/StikJIT/Info.plist
@@ -2,9 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleURLTypes</key>
-	<array>
-		<dict>
+        <key>BGTaskSchedulerPermittedIdentifiers</key>
+        <array>
+                <string>$(PRODUCT_BUNDLE_IDENTIFIER).continuedProcessing</string>
+        </array>
+        <key>CFBundleURLTypes</key>
+        <array>
+                <dict>
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
 			<key>CFBundleURLName</key>

--- a/StikJIT/JSSupport/RunJSView.swift
+++ b/StikJIT/JSSupport/RunJSView.swift
@@ -78,35 +78,12 @@ class RunJSViewModel: ObservableObject {
             if let exception = self.context?.exception {
                 self.logs.append(exception.debugDescription)
             }
-            
+
             self.logs.append("Script Execution Completed")
-            self.logs.append("You are safe to close the PIP Window.")
+            self.logs.append("You can safely leave StikDebug once this window is closed.")
         }
     }
 }
-
-struct RunJSViewPiP: View {
-    @Binding var model: RunJSViewModel?
-    @State var logs: [String] = []
-    let timer = Timer.publish(every: 0.034, on: .main, in: .common).autoconnect()
-    
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            ForEach(logs.suffix(6).indices, id: \.self) { index in
-                Text(logs.suffix(6)[index])
-                    .font(.system(size: 12))
-                    .foregroundStyle(.white)
-            }
-        }
-        .padding()
-        .onReceive(timer) { _ in
-            self.logs = model?.logs ?? []
-        }
-        .frame(width: 300, height: 150)
-    }
-}
-
 
 struct RunJSView: View {
     @ObservedObject var model: RunJSViewModel

--- a/StikJIT/StikJITApp.swift
+++ b/StikJIT/StikJITApp.swift
@@ -522,6 +522,7 @@ struct HeartbeatApp: App {
     init() {
         registerAdvancedOptionsDefault()
         newVerCheck()
+        BackgroundContinuation.setup()
         let fixMethod = class_getInstanceMethod(UIDocumentPickerViewController.self, #selector(UIDocumentPickerViewController.fix_init(forOpeningContentTypes:asCopy:)))!
         let origMethod = class_getInstanceMethod(UIDocumentPickerViewController.self, #selector(UIDocumentPickerViewController.init(forOpeningContentTypes:asCopy:)))!
         method_exchangeImplementations(origMethod, fixMethod)

--- a/StikJIT/Utilities/BackgroundContinuation.swift
+++ b/StikJIT/Utilities/BackgroundContinuation.swift
@@ -1,0 +1,147 @@
+import Foundation
+import OSLog
+
+#if canImport(BackgroundTasks)
+import BackgroundTasks
+#endif
+
+/// Represents an active continued-processing request so the caller can close it explicitly.
+struct BackgroundContinuationToken: Hashable {
+    fileprivate let id = UUID()
+}
+
+enum BackgroundContinuation {
+    private static let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.stik.StikJIT", category: "Background")
+
+    static func setup() {
+        #if canImport(BackgroundTasks)
+        if #available(iOS 26.0, *) {
+            BGContinuationController.shared.setup()
+        }
+        #endif
+    }
+
+    @discardableResult
+    static func begin(title: String, subtitle: String) -> BackgroundContinuationToken? {
+        #if canImport(BackgroundTasks)
+        if #available(iOS 26.0, *) {
+            return BGContinuationController.shared.begin(title: title, subtitle: subtitle)
+        }
+        #endif
+        logger.debug("BGContinuedProcessingTask unavailable on this OS")
+        return nil
+    }
+
+    static func end(success: Bool, token: BackgroundContinuationToken?) {
+        guard let token else { return }
+        #if canImport(BackgroundTasks)
+        if #available(iOS 26.0, *) {
+            BGContinuationController.shared.end(success: success, token: token)
+            return
+        }
+        #endif
+        logger.debug("No continued-processing task to finish")
+    }
+
+    static var isAvailable: Bool {
+        #if canImport(BackgroundTasks)
+        if #available(iOS 26.0, *) {
+            return BGContinuationController.shared.isConfigured
+        }
+        #endif
+        return false
+    }
+}
+
+#if canImport(BackgroundTasks)
+@available(iOS 26.0, *)
+private final class BGContinuationController {
+    static let shared = BGContinuationController()
+
+    private let scheduler = BGTaskScheduler.shared
+    private let taskIdentifier: String
+    private var registered = false
+    private var pendingToken: BackgroundContinuationToken?
+    private var activeToken: BackgroundContinuationToken?
+    private var activeTask: BGContinuedProcessingTask?
+    private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.stik.StikJIT", category: "Background")
+
+    private init() {
+        let baseIdentifier = Bundle.main.bundleIdentifier ?? "com.stik.StikJIT"
+        taskIdentifier = baseIdentifier + ".continuedProcessing"
+    }
+
+    var isConfigured: Bool { registered }
+
+    func setup() {
+        guard !registered else { return }
+        registered = scheduler.register(forTaskWithIdentifier: taskIdentifier, using: nil) { [weak self] task in
+            self?.handle(task: task)
+        }
+        if !registered {
+            logger.error("Failed to register continued-processing handler")
+            LogManager.shared.addErrorLog("Unable to register continued processing background handler.")
+        } else {
+            logger.debug("Registered continued-processing handler")
+        }
+    }
+
+    func begin(title: String, subtitle: String) -> BackgroundContinuationToken? {
+        setup()
+        guard registered else { return nil }
+
+        let request = BGContinuedProcessingTaskRequest(identifier: taskIdentifier, title: title, subtitle: subtitle)
+        request.strategy = .queue
+
+        let token = BackgroundContinuationToken()
+        do {
+            try scheduler.submit(request)
+            pendingToken = token
+            logger.info("Submitted continued-processing task request: \(title, privacy: .public)")
+            LogManager.shared.addInfoLog("Requested continued processing for \(title)")
+            return token
+        } catch {
+            logger.error("Failed to submit continued-processing task: \(error.localizedDescription, privacy: .public)")
+            LogManager.shared.addErrorLog("Unable to request continued processing: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    func end(success: Bool, token: BackgroundContinuationToken) {
+        if pendingToken == token {
+            scheduler.cancel(taskRequestWithIdentifier: taskIdentifier)
+            pendingToken = nil
+        }
+
+        if activeToken == token {
+            activeTask?.setTaskCompleted(success: success)
+            activeTask = nil
+            activeToken = nil
+            logger.info("Marked continued-processing task as completed: success=\(success)")
+            LogManager.shared.addInfoLog(success ? "Background continued processing finished." : "Background continued processing ended early.")
+        }
+    }
+
+    private func handle(task: BGTask) {
+        guard let continuedTask = task as? BGContinuedProcessingTask else {
+            task.setTaskCompleted(success: false)
+            return
+        }
+
+        activeTask = continuedTask
+        activeToken = pendingToken
+        pendingToken = nil
+
+        continuedTask.expirationHandler = { [weak self] in
+            guard let self else { return }
+            self.logger.warning("Continued-processing task expired")
+            self.activeTask?.setTaskCompleted(success: false)
+            self.activeTask = nil
+            if let activeToken {
+                LogManager.shared.addWarningLog("Background continued processing expired before completion.")
+            }
+            self.activeToken = nil
+        }
+    }
+}
+#endif

--- a/StikJIT/Views/HomeView.swift
+++ b/StikJIT/Views/HomeView.swift
@@ -7,7 +7,6 @@
 
 import SwiftUI
 import UniformTypeIdentifiers
-import Pipify
 import UIKit
 import WidgetKit
 
@@ -50,9 +49,8 @@ struct HomeView: View {
     @AppStorage("enableAdvancedOptions") private var enableAdvancedOptions = false
 
     @AppStorage("useDefaultScript") private var useDefaultScript = false
-    @AppStorage("enablePiP") private var enablePiP = true
+    @AppStorage("enablePiP") private var enableContinuedProcessing = true
     @State var scriptViewShow = false
-    @State var pipRequired = false
     @AppStorage("DefaultScriptName") var selectedScript = "attachDetach.js"
     @State var jsModel: RunJSViewModel?
     
@@ -270,12 +268,6 @@ struct HomeView: View {
                                      scriptName: autoScriptName,
                                      triggeredByURLScheme: false)
             }
-        }
-        .pipify(isPresented: Binding(
-            get: { pipRequired && enablePiP },
-            set: { newValue in pipRequired = newValue }
-        )) {
-            RunJSViewPiP(model: $jsModel)
         }
         .sheet(isPresented: $scriptViewShow) {
             NavigationView {
@@ -1020,16 +1012,30 @@ struct HomeView: View {
             }
             
             var callback: DebugAppCallback? = nil
+            var backgroundToken: BackgroundContinuationToken? = nil
             if ProcessInfo.processInfo.hasTXM, let sd = scriptData {
                 callback = getJsCallback(sd, name: scriptName ?? bundleID ?? "Script")
                 if triggeredByURLScheme { usleep(500000) }
-                pipRequired = true
-            } else {
-                pipRequired = false
+
+                if enableContinuedProcessing && BackgroundContinuation.isAvailable {
+                    let title = scriptName ?? bundleID ?? "Debug Session"
+                    let subtitle: String
+                    if let bundleID {
+                        subtitle = bundleID
+                    } else if let pid {
+                        subtitle = "PID \(pid)"
+                    } else {
+                        subtitle = "Debug Session"
+                    }
+                    backgroundToken = BackgroundContinuation.begin(title: title, subtitle: subtitle)
+                }
             }
-            
+
             let logger: LogFunc = { message in if let message { LogManager.shared.addInfoLog(message) } }
-            var success: Bool
+            var success: Bool = false
+            defer {
+                BackgroundContinuation.end(success: success, token: backgroundToken)
+            }
             if let pid {
                 success = JITEnableContext.shared.debugApp(withPID: Int32(pid), logger: logger, jsCallback: callback)
                 if success { DispatchQueue.main.async { addRecentPID(pid) } }
@@ -1048,7 +1054,6 @@ struct HomeView: View {
                 }
             }
             isProcessing = false
-            pipRequired = false
         }
     }
 

--- a/StikJIT/Views/SettingsView.swift
+++ b/StikJIT/Views/SettingsView.swift
@@ -14,7 +14,7 @@ struct SettingsView: View {
     @AppStorage("enableAdvancedOptions") private var enableAdvancedOptions = false
     @AppStorage("enableAdvancedBetaOptions") private var enableAdvancedBetaOptions = false
     @AppStorage("enableTesting") private var enableTesting = false
-    @AppStorage("enablePiP") private var enablePiP = false
+    @AppStorage("enablePiP") private var enableContinuedProcessing = false
     @AppStorage(UserDefaults.Keys.txmOverride) private var overrideTXMDetection = false
     @AppStorage("customAccentColor") private var customAccentColorHex: String = ""
     @AppStorage("appTheme") private var appThemeRaw: String = AppTheme.system.rawValue
@@ -332,8 +332,14 @@ struct SettingsView: View {
 
                 Toggle("Run Default Script After Connecting", isOn: $useDefaultScript)
                     .tint(accentColor)
-                Toggle("Picture in Picture", isOn: $enablePiP)
+                Toggle("Keep Running After Leaving App", isOn: $enableContinuedProcessing)
                     .tint(accentColor)
+                    .disabled(!BackgroundContinuation.isAvailable)
+                if !BackgroundContinuation.isAvailable {
+                    Text("Requires iOS 26 or later.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
                 Toggle(isOn: $overrideTXMDetection) {
                     VStack(alignment: .leading, spacing: 2) {
                         Text("Always Run Scripts")
@@ -349,7 +355,7 @@ struct SettingsView: View {
             .onChange(of: enableAdvancedOptions) { _, newValue in
                 if !newValue {
                     useDefaultScript = false
-                    enablePiP = false
+                    enableContinuedProcessing = false
                     enableAdvancedBetaOptions = false
                     enableTesting = false
                 }


### PR DESCRIPTION
## Summary
- replace the PiP-based script execution flow with a BGContinuedProcessingTask helper and wire it into app launch, HomeView, and Settings
- add the continued-processing identifier to the app Info.plist and update user messaging/logging around script completion
- drop the Pipify Swift package from the project and tidy related comments and UI labels

## Testing
- not run (iOS build requires Xcode)

------
https://chatgpt.com/codex/tasks/task_e_68e422a58624832d821b8a9787a4c278