### PR TITLE
Add PocketJ Launcher to universal script assignments

### DIFF
--- a/StikDebug/Support/AutoScriptAssignments.swift
+++ b/StikDebug/Support/AutoScriptAssignments.swift
@@ -13,6 +13,8 @@ extension ScriptStore {
         AutoScriptAssignment(
             appNames: [
                 "Amethyst",
+                "PocketJ Launcher",
+                "掌上Java启动器",
                 "MeloNX",
                 "Melo",
                 "XeniOS",


### PR DESCRIPTION
## Summary

Adds PocketJ Launcher to the automatic `universal.js` script assignments.

PocketJ Launcher is an open-source Minecraft: Java Edition launcher for iOS/iPadOS based on Amethyst-iOS.

Both localized display names are included:

- `PocketJ Launcher`
- `掌上Java启动器`

The universal script has been tested successfully with PocketJ Launcher on iOS 27.

Project:
https://github.com/EricoEC/PocketJLauncher